### PR TITLE
Cancel Github Action if new commit is pushed

### DIFF
--- a/.github/workflows/ktlint.yaml
+++ b/.github/workflows/ktlint.yaml
@@ -1,4 +1,9 @@
 name: ktlint
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on: [pull_request]
 jobs:
   ktlint:

--- a/.github/workflows/sonarcloud-analysis.yaml
+++ b/.github/workflows/sonarcloud-analysis.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
   SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}


### PR DESCRIPTION
## 📋 Changelist Summary
Added concurrency tag to cancel Github Action if new commit is added. 

## 💬 Description
Added concurrency tag with the identifier of the Github Action and the PR number id in order to cancel the workflow execution if a new commit is added. This will fix the actions being executed more than once at the same time.