### PR TITLE
Created GuildQueueDispatcher

### DIFF
--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -71,8 +71,8 @@ class Bot(
                 ?: interaction.respondPublic { content = "You need to be in a voice channel" }.let { return@on }
             val textChannel = interaction.channel.asChannelOrNull()
                 ?: interaction.respondPublic { content = "You need to be in a text channel" }.let { return@on }
-            val guildId = interaction.data.guildId.value ?:
-                interaction.respondPublic { content = "You need to be in a guild" }.let { return@on }
+            val guildId = interaction.data.guildId.value
+                ?: interaction.respondPublic { content = "You need to be in a guild" }.let { return@on }
             val input: String = interaction.command.strings["pepe"]?.takeUnless { it.isEmpty() }
                 ?: interaction.respondPublic { content = "You need to give provide a url" }.let { return@on }
             interaction.respondPublic { content = "Searching the song" }

--- a/src/main/kotlin/di/ServicesModule.kt
+++ b/src/main/kotlin/di/ServicesModule.kt
@@ -5,6 +5,7 @@ import es.wokis.dispatchers.AppDispatchersImpl
 import es.wokis.services.config.ConfigService
 import es.wokis.services.lavaplayer.AudioPlayerManagerProvider
 import es.wokis.services.processor.MessageProcessorService
+import es.wokis.services.queue.GuildQueueDispatcher
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
@@ -12,6 +13,7 @@ val servicesModule = module {
     singleOf(::ConfigService)
     singleOf(::MessageProcessorService)
     singleOf(::AudioPlayerManagerProvider)
+    singleOf(::GuildQueueDispatcher)
 
     single<AppDispatchers> { AppDispatchersImpl() }
 }

--- a/src/main/kotlin/services/queue/GuildQueueDispatcher.kt
+++ b/src/main/kotlin/services/queue/GuildQueueDispatcher.kt
@@ -1,0 +1,39 @@
+package es.wokis.services.queue
+
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior
+import dev.kord.core.entity.channel.MessageChannel
+import es.wokis.dispatchers.AppDispatchers
+import es.wokis.services.lavaplayer.AudioPlayerManagerProvider
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+
+class GuildQueueDispatcher(
+    private val audioPlayerManagerProvider: AudioPlayerManagerProvider,
+    private val appDispatchers: AppDispatchers
+) {
+
+    private val guildQueues: MutableMap<Snowflake, GuildLavaPlayerService> = mutableMapOf()
+
+    fun getOrCreateLavaPlayerService(
+        guildId: Snowflake,
+        textChannel: MessageChannel,
+        voiceChannel: BaseVoiceChannelBehavior
+    ): GuildLavaPlayerService = guildQueues[guildId] ?: createLavaPlayer(
+        guild = guildId,
+        textChannel = textChannel,
+        voiceChannel = voiceChannel
+    )
+
+    private fun createLavaPlayer(
+        guild: Snowflake,
+        textChannel: MessageChannel,
+        voiceChannel: BaseVoiceChannelBehavior
+    ): GuildLavaPlayerService = GuildLavaPlayerService(
+        appDispatchers = appDispatchers,
+        textChannel = textChannel,
+        voiceChannel = voiceChannel,
+        audioPlayerManager = audioPlayerManagerProvider.createAudioPlayerManager()
+    ).also {
+        guildQueues[guild] = it
+    }
+}

--- a/src/test/kotlin/bot/BotTest.kt
+++ b/src/test/kotlin/bot/BotTest.kt
@@ -5,12 +5,10 @@ import dev.kord.common.entity.DiscordBotActivity
 import dev.kord.common.entity.PresenceStatus
 import dev.kord.gateway.DiscordPresence
 import es.wokis.bot.Bot
-import es.wokis.dispatchers.AppDispatchers
 import es.wokis.services.config.ConfigService
-import es.wokis.services.lavaplayer.AudioPlayerManagerProvider
 import es.wokis.services.processor.MessageProcessorService
+import es.wokis.services.queue.GuildQueueDispatcher
 import io.mockk.mockk
-import mock.TestDispatchers
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -18,14 +16,12 @@ class BotTest {
 
     private val config: ConfigService = mockk()
     private val messageProcessor: MessageProcessorService = mockk()
-    private val appDispatchers: AppDispatchers = TestDispatchers()
-    private val audioPlayerManagerProvider: AudioPlayerManagerProvider = mockk()
+    private val guildQueueDispatcher: GuildQueueDispatcher = mockk()
 
     private val bot = Bot(
         config = config,
         messageProcessor = messageProcessor,
-        appDispatchers = appDispatchers,
-        audioPlayerManagerProvider = audioPlayerManagerProvider
+        guildQueueDispatcher = guildQueueDispatcher
     )
 
     @Test

--- a/src/test/kotlin/services/lavaplayer/AudioPlayerManagerProviderTest.kt
+++ b/src/test/kotlin/services/lavaplayer/AudioPlayerManagerProviderTest.kt
@@ -1,4 +1,4 @@
-package lavaplayer
+package services.lavaplayer
 
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
 import es.wokis.services.config.ConfigService

--- a/src/test/kotlin/services/lavaplayer/GuildLavaPlayerServiceTest.kt
+++ b/src/test/kotlin/services/lavaplayer/GuildLavaPlayerServiceTest.kt
@@ -1,4 +1,4 @@
-package lavaplayer
+package services.lavaplayer
 
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior

--- a/src/test/kotlin/services/queue/GuildQueueDispatcherTest.kt
+++ b/src/test/kotlin/services/queue/GuildQueueDispatcherTest.kt
@@ -1,0 +1,117 @@
+package services.queue
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
+import com.sedmelluq.discord.lavaplayer.player.event.AudioEventListener
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior
+import dev.kord.core.entity.channel.MessageChannel
+import es.wokis.services.lavaplayer.AudioPlayerManagerProvider
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.queue.GuildQueueDispatcher
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import mock.TestDispatchers
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class GuildQueueDispatcherTest {
+
+    private val audioPlayerManagerProvider: AudioPlayerManagerProvider = mockk()
+    private val appDispatchers = TestDispatchers()
+
+    private val guildQueueDispatcher = GuildQueueDispatcher(
+        audioPlayerManagerProvider = audioPlayerManagerProvider,
+        appDispatchers = appDispatchers
+    )
+
+    @Test
+    fun `Given dispatcher When getOrCreateLavaPlayerService is called Then create and return GuildLavaPlayer for given Guild`() {
+        // Given
+        val guildId = Snowflake(123)
+        val textChannel: MessageChannel = mockk()
+        val voiceChannel: BaseVoiceChannelBehavior = mockk()
+        val audioPlayerManager: AudioPlayerManager = mockk()
+
+        every { audioPlayerManagerProvider.createAudioPlayerManager() } returns audioPlayerManager
+        every { audioPlayerManager.createPlayer() } returns mockk {
+            justRun { addListener(any<AudioEventListener>()) }
+        }
+
+        // When
+        val actual = guildQueueDispatcher.getOrCreateLavaPlayerService(
+            guildId = guildId,
+            textChannel = textChannel,
+            voiceChannel = voiceChannel
+        )
+
+        // Then
+        assertTrue(actual is GuildLavaPlayerService)
+    }
+
+    @Test
+    fun `Given dispatcher When getOrCreateLavaPlayerService is called for two different guilds Then create and return GuildLavaPlayer for each Guild`() {
+        // Given
+        val guildId1 = Snowflake(123)
+        val guildId2 = Snowflake(456)
+        val textChannel: MessageChannel = mockk()
+        val voiceChannel: BaseVoiceChannelBehavior = mockk()
+        val audioPlayerManager: AudioPlayerManager = mockk()
+
+        every { audioPlayerManagerProvider.createAudioPlayerManager() } returns audioPlayerManager
+        every { audioPlayerManager.createPlayer() } returns mockk {
+            justRun { addListener(any<AudioEventListener>()) }
+        }
+
+        // When
+        val lavaPlayerGuild1 = guildQueueDispatcher.getOrCreateLavaPlayerService(
+            guildId = guildId1,
+            textChannel = textChannel,
+            voiceChannel = voiceChannel
+        )
+
+        val lavaPlayerGuild2 = guildQueueDispatcher.getOrCreateLavaPlayerService(
+            guildId = guildId2,
+            textChannel = textChannel,
+            voiceChannel = voiceChannel
+        )
+
+        // Then
+        assertFalse(lavaPlayerGuild1 == lavaPlayerGuild2)
+    }
+
+    @Test
+    fun `Given dispatcher When getOrCreateLavaPlayerService is called for the same guild twice Then create and return the same GuildLavaPlayer`() {
+        // Given
+        val guildId1 = Snowflake(123)
+        val guildId2 = Snowflake(123)
+        val textChannel: MessageChannel = mockk()
+        val voiceChannel: BaseVoiceChannelBehavior = mockk()
+        val audioPlayerManager: AudioPlayerManager = mockk()
+
+        every { audioPlayerManagerProvider.createAudioPlayerManager() } returns audioPlayerManager
+        every { audioPlayerManager.createPlayer() } returns mockk {
+            justRun { addListener(any<AudioEventListener>()) }
+        }
+
+        // When
+        val lavaPlayerFirst = guildQueueDispatcher.getOrCreateLavaPlayerService(
+            guildId = guildId1,
+            textChannel = textChannel,
+            voiceChannel = voiceChannel
+        )
+
+        val lavaPlayerSecond = guildQueueDispatcher.getOrCreateLavaPlayerService(
+            guildId = guildId2,
+            textChannel = textChannel,
+            voiceChannel = voiceChannel
+        )
+
+        // Then
+        assertEquals(lavaPlayerFirst, lavaPlayerSecond)
+        assertSame(lavaPlayerFirst, lavaPlayerSecond)
+    }
+}


### PR DESCRIPTION
Solves #12 

## 📋 Changelist Summary
- Created GuildQueueDispatcher and tests
- Moved some tests to their correct folder

## 💬 Description
Created GuildQueueDispatcher to manage queue and player for each Guild. This means the bot can be connected on different Guilds playing different tracks at the same time.