### PR TITLE
Fixed disconnect bug

### DIFF
--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -71,14 +71,12 @@ class GuildLavaPlayerService(
         }
     }
 
-    @OptIn(KordVoice::class)
     private fun setUpTimer() {
         leaveTimer = Timer().apply {
             schedule(LEAVE_DELAY) {
                 if (queue.isNotEmpty()) return@schedule
                 coroutineScope.launch {
-                    voiceConnection?.leave()
-                    voiceConnection = null
+                    resetVoiceConnection()
                 }
             }
         }
@@ -167,5 +165,18 @@ class GuildLavaPlayerService(
     private suspend fun onLoadFailed(exception: FriendlyException) {
         Log.error("GuildLavaPlayerService onLoadFailed", exception)
         textChannel.createMessage("Load failed: ${exception.message}")
+    }
+
+    suspend fun handleDisconnectEvent() {
+        queue.clear()
+        player.stopTrack()
+        resetVoiceConnection()
+        playTrackRetries = 0
+    }
+
+    @OptIn(KordVoice::class)
+    private suspend fun resetVoiceConnection() {
+        voiceConnection?.leave()
+        voiceConnection = null
     }
 }

--- a/src/main/kotlin/services/queue/GuildQueueDispatcher.kt
+++ b/src/main/kotlin/services/queue/GuildQueueDispatcher.kt
@@ -24,6 +24,8 @@ class GuildQueueDispatcher(
         voiceChannel = voiceChannel
     )
 
+    fun getLavaPlayerService(guildId: Snowflake): GuildLavaPlayerService? = guildQueues[guildId]
+
     private fun createLavaPlayer(
         guild: Snowflake,
         textChannel: MessageChannel,

--- a/src/test/kotlin/services/queue/GuildQueueDispatcherTest.kt
+++ b/src/test/kotlin/services/queue/GuildQueueDispatcherTest.kt
@@ -12,7 +12,7 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import mock.TestDispatchers
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -113,5 +113,44 @@ class GuildQueueDispatcherTest {
         // Then
         assertEquals(lavaPlayerFirst, lavaPlayerSecond)
         assertSame(lavaPlayerFirst, lavaPlayerSecond)
+    }
+
+    @Test
+    fun `Given dispatcher When getLavaPlayerService is called on an unknown guild Then return null`() {
+        // Given
+        val guildId = Snowflake(123)
+        val audioPlayerManager: AudioPlayerManager = mockk()
+
+        every { audioPlayerManagerProvider.createAudioPlayerManager() } returns audioPlayerManager
+        every { audioPlayerManager.createPlayer() } returns mockk {
+            justRun { addListener(any<AudioEventListener>()) }
+        }
+
+        // When
+        val actual = guildQueueDispatcher.getLavaPlayerService(guildId = guildId)
+
+        // Then
+        assertNull(actual)
+    }
+
+    @Test
+    fun `Given dispatcher When getLavaPlayerService is called Then return given guild audio player`() {
+        // Given
+        val guildId = Snowflake(123)
+        val textChannel: MessageChannel = mockk()
+        val voiceChannel: BaseVoiceChannelBehavior = mockk()
+        val audioPlayerManager: AudioPlayerManager = mockk()
+
+        every { audioPlayerManagerProvider.createAudioPlayerManager() } returns audioPlayerManager
+        every { audioPlayerManager.createPlayer() } returns mockk {
+            justRun { addListener(any<AudioEventListener>()) }
+        }
+        guildQueueDispatcher.getOrCreateLavaPlayerService(guildId, textChannel, voiceChannel)
+
+        // When
+        val actual = guildQueueDispatcher.getLavaPlayerService(guildId = guildId)
+
+        // Then
+        assertNotNull(actual)
     }
 }


### PR DESCRIPTION
Solves #49.

## 📋 Changelist Summary
- Implemented VoiceStateUpdateEvent listener to clear LavaPlayer's queue and voice state

## 💬 Description
Implemented VoiceStateUpdateEvent listener to clear LavaPlayer's queue and voice state in order to fix the bug that ocurred when the bot was manually disconnected from the voice channel. Now, it will clear the queue, the voice connection and reset some values to fresh state. 

## 🐞 Steps to reproduce bug
Steps to reproduce the behavior:

1. Ask the bot to play something, like a playlist
2. Disconnect manually the bot from the voice channel by right clicking it and disconnect
3. Bot keeps sending "Now playing" message
