### PR TITLE
Add LavaSrc library and implement Deezer support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     // Lavaplayer
     implementation(libs.lavaplayer)
     implementation(libs.lavaplayer.youtube)
+    implementation(libs.lavaplayer.lavasrc)
 
     // Tests
     testImplementation(libs.kotlin.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ koin = "3.5.6"
 serialization = "1.7.2"
 lavaplayer = "2.2.3"
 lavaplayer-youtube = "1.11.4"
+lavaplayer-lavasrc = "4.4.1"
 
 [libraries]
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -22,6 +23,7 @@ kord-rest = { module = "dev.kord:kord-rest", version.ref = "kord" }
 kord-gateway = { module = "dev.kord:kord-gateway", version.ref = "kord" }
 lavaplayer = { module = "dev.arbjerg:lavaplayer", version.ref = "lavaplayer" }
 lavaplayer-youtube = { module = "dev.lavalink.youtube:v2", version.ref = "lavaplayer-youtube"}
+lavaplayer-lavasrc = { module = "com.github.topi314.lavasrc:lavasrc-plugin", version.ref = "lavaplayer-lavasrc"}
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }

--- a/src/main/kotlin/exceptions/ConfigValidationExceptions.kt
+++ b/src/main/kotlin/exceptions/ConfigValidationExceptions.kt
@@ -1,0 +1,4 @@
+package es.wokis.exceptions
+
+class EmptyDiscordTokenException : IllegalArgumentException("Discord token shouldn't be empty")
+class EmptyDeezerMasterDecryptionKeyException : IllegalArgumentException("Deezer is enabled but no master decryption key was provided")

--- a/src/main/kotlin/exceptions/EmptyDiscordTokenException.kt
+++ b/src/main/kotlin/exceptions/EmptyDiscordTokenException.kt
@@ -1,3 +1,0 @@
-package es.wokis.exceptions
-
-class EmptyDiscordTokenException : IllegalArgumentException("Discord token shouldn't be empty")

--- a/src/main/kotlin/services/config/ConfigBO.kt
+++ b/src/main/kotlin/services/config/ConfigBO.kt
@@ -14,7 +14,9 @@ data class Config(
     @SerialName("youtube")
     val youtube: YouTubeConfig,
     @SerialName("hugging_chat")
-    val huggingChat: HuggingChatConfig
+    val huggingChat: HuggingChatConfig,
+    @SerialName("deezer")
+    val deezer: DeezerConfig
 )
 
 @Serializable
@@ -43,4 +45,14 @@ data class HuggingChatConfig(
     val user: String,
     @SerialName("password")
     val password: String
+)
+
+@Serializable
+data class DeezerConfig(
+    @SerialName("enabled")
+    val enabled: Boolean,
+    @SerialName("master_decryption_key")
+    val masterDecryptionKey: String,
+    @SerialName("arl_token")
+    val arlToken: String,
 )

--- a/src/main/kotlin/services/config/ConfigService.kt
+++ b/src/main/kotlin/services/config/ConfigService.kt
@@ -1,5 +1,6 @@
 package es.wokis.services.config
 
+import es.wokis.exceptions.EmptyDeezerMasterDecryptionKeyException
 import es.wokis.exceptions.EmptyDiscordTokenException
 import es.wokis.utils.getOrCreateFile
 import kotlinx.serialization.json.Json
@@ -22,5 +23,10 @@ class ConfigService {
 }
 
 fun Config.validate() {
-    if (discordBotToken.isEmpty()) throw EmptyDiscordTokenException()
+    if (discordBotToken.isEmpty()) {
+        throw EmptyDiscordTokenException()
+    }
+    if (deezer.enabled && deezer.masterDecryptionKey.isEmpty()) {
+        throw EmptyDeezerMasterDecryptionKeyException()
+    }
 }

--- a/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
+++ b/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
@@ -4,6 +4,7 @@ import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers
 import dev.lavalink.youtube.YoutubeAudioSourceManager
+import com.github.topi314.lavasrc.deezer.DeezerAudioSourceManager
 import es.wokis.services.config.ConfigService
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager as DeprecatedYoutubeAudioSourceManager
 
@@ -16,6 +17,14 @@ class AudioPlayerManagerProvider(
             useOauth2(configService.config.youtube.oauth2Token, true)
         }
         this.registerSourceManager(ytSourceManager)
+        if (configService.config.deezer.enabled) {
+            this.registerSourceManager(
+                DeezerAudioSourceManager(
+                    configService.config.deezer.masterDecryptionKey,
+                    configService.config.deezer.arlToken
+                )
+            )
+        }
         AudioSourceManagers.registerLocalSource(this)
         AudioSourceManagers.registerRemoteSources(
             this,

--- a/src/main/resources/template/config_template.json
+++ b/src/main/resources/template/config_template.json
@@ -14,5 +14,10 @@
     "enabled": false,
     "user": "hugging_chat_user",
     "password": "hugging_chat_password"
+  },
+  "deezer": {
+    "enabled": false,
+    "master_decryption_key": "",
+    "arl_token": ""
   }
 }

--- a/src/test/kotlin/services/config/ConfigServiceTest.kt
+++ b/src/test/kotlin/services/config/ConfigServiceTest.kt
@@ -1,5 +1,6 @@
 package services.config
 
+import es.wokis.exceptions.EmptyDeezerMasterDecryptionKeyException
 import es.wokis.exceptions.EmptyDiscordTokenException
 import es.wokis.services.config.*
 import io.mockk.every
@@ -41,6 +42,23 @@ class ConfigServiceTest {
         } catch (e: Throwable) {
             // Then
             assertTrue(e is EmptyDiscordTokenException)
+        }
+    }
+
+    @Test
+    fun `Given config with Deezer enabled but empty decryption key When config is validated Then throw EmptyDeezerMasterDecryptionKeyException`() {
+        // Given
+        val config = mockk<Config> {
+            every { deezer.enabled } returns true
+            every { deezer.masterDecryptionKey } returns ""
+        }
+
+        // When
+        try {
+            config.validate()
+        } catch (e: Throwable) {
+            // Then
+            assertTrue(e is EmptyDeezerMasterDecryptionKeyException)
         }
     }
 


### PR DESCRIPTION
Solves #38, #50

## 📋 Changelist Summary
This PR adds LavaSrc library and uses DeezerAudioSourceManager to add Deezer music support.

## 💬 Description
For Deezer to work you need to add the Deezer master decryption key (we can't add it here for legal reasons but it's easy to find, just search for it) and the ARL token (register an account for it or just search it out there). Additionally, LavaSrc has compatibility with a lot of services, including Spotify, so we can use it for more services in the future.