### PR TITLE
Fixed bot disconnecting when a user leaves a voice channel

### DIFF
--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -60,6 +60,7 @@ class Bot(
         }
 
         bot.on<VoiceStateUpdateEvent> {
+            if (state.userId != bot.selfId) return@on
             if (state.data.channelId == null) {
                 handleDisconnectEvent(state.guildId)
             }


### PR DESCRIPTION
<!-- Change #issue with the issue it is related, if it applies -->
Solves #58.

## 📋 Changelist Summary
Bot doesn't leave when someone on VC leaves.

## 💬 Description
When the bot is connected and playing something on the VC, if a user leaves, the bot also is disconnected. This bug was introduced by #51.

## 🐞 Steps to reproduce bug
Steps to reproduce the behavior:

1. Enter a voice channel
2. Connect the bot by using /test
3. Leave the channel
4. The bot is also disconnected.