### PR TITLE
Added support to Spotify using LavaSrc & added yt's poToken

### DIFF
--- a/src/main/kotlin/services/config/ConfigBO.kt
+++ b/src/main/kotlin/services/config/ConfigBO.kt
@@ -16,7 +16,9 @@ data class Config(
     @SerialName("hugging_chat")
     val huggingChat: HuggingChatConfig,
     @SerialName("deezer")
-    val deezer: DeezerConfig
+    val deezer: DeezerConfig,
+    @SerialName("spotify")
+    val spotify: SpotifyConfig
 )
 
 @Serializable
@@ -34,7 +36,11 @@ data class DatabaseConfig(
 @Serializable
 data class YouTubeConfig(
     @SerialName("oauth2_token")
-    val oauth2Token: String?
+    val oauth2Token: String?,
+    @SerialName("po_token")
+    val poToken: String?,
+    @SerialName("visitor_data")
+    val visitorData: String?
 )
 
 @Serializable
@@ -55,4 +61,14 @@ data class DeezerConfig(
     val masterDecryptionKey: String,
     @SerialName("arl_token")
     val arlToken: String,
+)
+
+@Serializable
+data class SpotifyConfig(
+    @SerialName("enabled")
+    val enabled: Boolean,
+    @SerialName("client_id")
+    val clientId: String,
+    @SerialName("client_secret")
+    val clientSecret: String
 )

--- a/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
+++ b/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
@@ -5,6 +5,9 @@ import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers
 import dev.lavalink.youtube.YoutubeAudioSourceManager
 import com.github.topi314.lavasrc.deezer.DeezerAudioSourceManager
+import com.github.topi314.lavasrc.mirror.DefaultMirroringAudioTrackResolver
+import com.github.topi314.lavasrc.spotify.SpotifySourceManager
+import dev.lavalink.youtube.clients.Web
 import es.wokis.services.config.ConfigService
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager as DeprecatedYoutubeAudioSourceManager
 
@@ -15,6 +18,11 @@ class AudioPlayerManagerProvider(
     fun createAudioPlayerManager(): AudioPlayerManager = DefaultAudioPlayerManager().apply {
         val ytSourceManager = YoutubeAudioSourceManager().apply {
             useOauth2(configService.config.youtube.oauth2Token, true)
+            Web.setPoTokenAndVisitorData(
+                configService.config.youtube.poToken,
+                configService.config.youtube.visitorData,
+
+            )
         }
         this.registerSourceManager(ytSourceManager)
         if (configService.config.deezer.enabled) {
@@ -22,6 +30,17 @@ class AudioPlayerManagerProvider(
                 DeezerAudioSourceManager(
                     configService.config.deezer.masterDecryptionKey,
                     configService.config.deezer.arlToken
+                )
+            )
+        }
+        if (configService.config.spotify.enabled) {
+            this.registerSourceManager(
+                SpotifySourceManager(
+                    configService.config.spotify.clientId,
+                    configService.config.spotify.clientSecret,
+                    null,
+                    this,
+                    DefaultMirroringAudioTrackResolver(null)
                 )
             )
         }

--- a/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
+++ b/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
@@ -20,8 +20,7 @@ class AudioPlayerManagerProvider(
             useOauth2(configService.config.youtube.oauth2Token, true)
             Web.setPoTokenAndVisitorData(
                 configService.config.youtube.poToken,
-                configService.config.youtube.visitorData,
-
+                configService.config.youtube.visitorData
             )
         }
         this.registerSourceManager(ytSourceManager)

--- a/src/main/resources/template/config_template.json
+++ b/src/main/resources/template/config_template.json
@@ -8,7 +8,9 @@
     "database": "db_database"
   },
   "youtube": {
-    "oauth2_token": null
+    "oauth2_token": null,
+    "po_token": null,
+    "visitor_data": null
   },
   "hugging_chat": {
     "enabled": false,
@@ -19,5 +21,10 @@
     "enabled": false,
     "master_decryption_key": "",
     "arl_token": ""
+  },
+  "spotify": {
+    "enabled": false,
+    "client_id": "",
+    "client_secret": ""
   }
 }

--- a/src/test/kotlin/services/lavaplayer/AudioPlayerManagerProviderTest.kt
+++ b/src/test/kotlin/services/lavaplayer/AudioPlayerManagerProviderTest.kt
@@ -18,6 +18,9 @@ class AudioPlayerManagerProviderTest {
         // Given
         every { configService.config.youtube.oauth2Token } returns null
         every { configService.config.deezer.enabled } returns false
+        every { configService.config.spotify.enabled } returns false
+        every { configService.config.youtube.poToken } returns null
+        every { configService.config.youtube.visitorData } returns null
 
         // When
         val actual = audioPlayerManagerProvider.createAudioPlayerManager()


### PR DESCRIPTION
<!-- Change #issue with the issue it is related, if it applies -->
Solves #34.

## 📋 Changelist Summary
- Added Spotify Audio Manager
- Added poToken support for Yotube Audio Manager

## 💬 Description
Added Spotify Audio Manager to support Spotify links and search. Spotify doesn't require anything to work, as of right now every api call seems to work without a client id nor a client secret. Although right now it works, maybe that changes in the future, so we have added those values on the config to be future proof.

Also, added support for poToken for Yotuube. Youtube may work without poToken, visitorId or oauth2 token, but it will be most definitely more stable with poToken and/or oauth2.