### PR TITLE
Created skip and shuffle commands

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kotlin-coroutines-test = "1.10.1"
 koin = "4.0.2"
 serialization = "1.8.0"
 lavaplayer = "2.2.3"
-lavaplayer-youtube = "1.11.4"
+lavaplayer-youtube = "1.11.5"
 lavaplayer-lavasrc = "4.4.1"
 idea-ext = "1.1.8"
 

--- a/src/main/kotlin/commands/CommandsEnum.kt
+++ b/src/main/kotlin/commands/CommandsEnum.kt
@@ -2,7 +2,9 @@ package es.wokis.commands
 
 enum class CommandsEnum(val commandName: String) {
     PLAY("play"),
-    QUEUE("queue");
+    QUEUE("queue"),
+    SKIP("skip"),
+    SHUFFLE("shuffle");
 
     companion object {
         fun forCommandName(commandName: String) = entries.find { it.commandName == commandName }

--- a/src/main/kotlin/commands/shuffle/ShuffleCommand.kt
+++ b/src/main/kotlin/commands/shuffle/ShuffleCommand.kt
@@ -1,0 +1,50 @@
+package es.wokis.commands.shuffle
+
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
+import es.wokis.commands.Command
+import es.wokis.commands.CommandsEnum
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+import es.wokis.utils.orDefaultLocale
+
+class ShuffleCommand(
+    private val guildQueueService: GuildQueueService,
+    private val localizationService: LocalizationService
+) : Command {
+
+    override fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
+        commandBuilder.apply {
+            input(
+                name = CommandsEnum.SHUFFLE.commandName,
+                description = localizationService.getString(key = LocalizationKeys.SHUFFLE_COMMAND_DESCRIPTION)
+            ) {
+                descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.SHUFFLE_COMMAND_DESCRIPTION)
+            }
+        }
+    }
+
+    override suspend fun onExecute(
+        interaction: ChatInputCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior
+    ) {
+        try {
+            val locale = interaction.guildLocale.orDefaultLocale()
+            val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
+            guildLavaPlayerService.shuffle()
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.SHUFFLE_COMMAND_RESPONSE,
+                    locale = locale
+                )
+            }
+        } catch (exc: IllegalStateException) {
+            response.respond {
+                content = exc.message
+            }
+        }
+    }
+}

--- a/src/main/kotlin/commands/skip/SkipCommand.kt
+++ b/src/main/kotlin/commands/skip/SkipCommand.kt
@@ -1,0 +1,50 @@
+package es.wokis.commands.skip
+
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
+import es.wokis.commands.Command
+import es.wokis.commands.CommandsEnum
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+import es.wokis.utils.orDefaultLocale
+
+class SkipCommand(
+    private val guildQueueService: GuildQueueService,
+    private val localizationService: LocalizationService
+) : Command {
+
+    override fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
+        commandBuilder.apply {
+            input(
+                name = CommandsEnum.SKIP.commandName,
+                description = localizationService.getString(key = LocalizationKeys.SKIP_COMMAND_DESCRIPTION)
+            ) {
+                descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.SKIP_COMMAND_DESCRIPTION)
+            }
+        }
+    }
+
+    override suspend fun onExecute(
+        interaction: ChatInputCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior
+    ) {
+        try {
+            val locale = interaction.guildLocale.orDefaultLocale()
+            val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
+            guildLavaPlayerService.skip()
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.SKIP_COMMAND_RESPONSE,
+                    locale = locale
+                )
+            }
+        } catch (exc: IllegalStateException) {
+            response.respond {
+                content = exc.message
+            }
+        }
+    }
+}

--- a/src/main/kotlin/di/CommandModule.kt
+++ b/src/main/kotlin/di/CommandModule.kt
@@ -2,10 +2,14 @@ package es.wokis.di
 
 import es.wokis.commands.queue.QueueCommand
 import commands.play.PlayCommand
+import es.wokis.commands.shuffle.ShuffleCommand
+import es.wokis.commands.skip.SkipCommand
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val commandModule = module {
     singleOf(::PlayCommand)
     singleOf(::QueueCommand)
+    singleOf(::SkipCommand)
+    singleOf(::ShuffleCommand)
 }

--- a/src/main/kotlin/localization/LocalizationKeys.kt
+++ b/src/main/kotlin/localization/LocalizationKeys.kt
@@ -23,4 +23,8 @@ object LocalizationKeys {
     const val QUEUE_EMBED_FOOTER = "queue_embed_footer"
     const val QUEUE_PREVIOUS_BUTTON_LABEL = "queue_previous_button_label"
     const val QUEUE_NEXT_BUTTON_LABEL = "queue_next_button_label"
+    const val SKIP_COMMAND_DESCRIPTION = "skip_command_description"
+    const val SKIP_COMMAND_RESPONSE = "skip_command_response"
+    const val SHUFFLE_COMMAND_DESCRIPTION = "shuffle_command_description"
+    const val SHUFFLE_COMMAND_RESPONSE = "shuffle_command_response"
 }

--- a/src/main/kotlin/services/commands/CommandHandlerService.kt
+++ b/src/main/kotlin/services/commands/CommandHandlerService.kt
@@ -10,6 +10,8 @@ import es.wokis.commands.CommandsEnum
 import es.wokis.commands.ComponentsEnum
 import es.wokis.commands.queue.QueueCommand
 import commands.play.PlayCommand
+import es.wokis.commands.shuffle.ShuffleCommand
+import es.wokis.commands.skip.SkipCommand
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 
@@ -28,12 +30,16 @@ interface CommandHandlerService {
 class CommandHandlerServiceImpl(
     private val playCommand: PlayCommand,
     private val queueCommand: QueueCommand,
+    private val skipCommand: SkipCommand,
+    private val shuffleCommand: ShuffleCommand,
     private val localizationService: LocalizationService
 ) : CommandHandlerService {
 
     override fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
         playCommand.onRegisterCommand(commandBuilder)
         queueCommand.onRegisterCommand(commandBuilder)
+        skipCommand.onRegisterCommand(commandBuilder)
+        shuffleCommand.onRegisterCommand(commandBuilder)
     }
 
     override suspend fun onExecute(
@@ -45,6 +51,10 @@ class CommandHandlerServiceImpl(
             CommandsEnum.PLAY -> playCommand.onExecute(interaction, response)
 
             CommandsEnum.QUEUE -> queueCommand.onExecute(interaction, response)
+
+            CommandsEnum.SKIP -> skipCommand.onExecute(interaction, response)
+
+            CommandsEnum.SHUFFLE -> shuffleCommand.onExecute(interaction, response)
 
             null -> respondUnknownCommand(response, interaction.guildLocale, commandName)
         }

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -104,11 +104,15 @@ class GuildLavaPlayerService(
             setUpTimer()
         }
         if (endReason?.mayStartNext == true && queue.isNotEmpty()) {
-            resetTimer()
-            replayTrackRetry.reset()
-            isRetrying = false
-            nextTrack()
+            playNextTrack()
         }
+    }
+
+    private fun playNextTrack() {
+        resetTimer()
+        replayTrackRetry.reset()
+        isRetrying = false
+        nextTrack()
     }
 
     private fun setUpTimer() {
@@ -148,6 +152,7 @@ class GuildLavaPlayerService(
 
     fun skip() {
         player.stopTrack()
+        playNextTrack()
     }
 
     suspend fun stop() {

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -92,18 +92,18 @@ class GuildLavaPlayerService(
                     player.playTrack(track?.makeClone())
                 }
             } catch (_: IllegalStateException) {
-                tryPlayNextTrack(endReason)
+                tryPlayNextTrack()
             }
             return
         }
-        tryPlayNextTrack(endReason)
+        tryPlayNextTrack()
     }
 
-    private fun tryPlayNextTrack(endReason: AudioTrackEndReason?) {
+    private fun tryPlayNextTrack() {
         if (queue.isEmpty()) {
             setUpTimer()
         }
-        if (endReason?.mayStartNext == true && queue.isNotEmpty()) {
+        if (queue.isNotEmpty()) {
             playNextTrack()
         }
     }
@@ -152,7 +152,6 @@ class GuildLavaPlayerService(
 
     fun skip() {
         player.stopTrack()
-        playNextTrack()
     }
 
     suspend fun stop() {

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -91,7 +91,8 @@ class GuildLavaPlayerService(
                     isRetrying = true
                     player.playTrack(track?.makeClone())
                 }
-            } catch (_: IllegalStateException) {
+            } catch (e: IllegalStateException) {
+                Log.error("An error has occurred on onTrackEnd", exception = e)
                 tryPlayNextTrack()
             }
             return

--- a/src/main/resources/lang/lang.yml
+++ b/src/main/resources/lang/lang.yml
@@ -20,3 +20,7 @@ queue_embed_description: Currently there are %d tracks on %s's queue
 queue_embed_footer: Page %d out of %d
 queue_previous_button_label: Previous
 queue_next_button_label: Next
+skip_command_description: Stops current playing track
+skip_command_response: Track skipped
+shuffle_command_description: Reorders current queue randomly
+shuffle_command_response: Reordered current queue randomly

--- a/src/main/resources/lang/lang_es-ES.yml
+++ b/src/main/resources/lang/lang_es-ES.yml
@@ -20,3 +20,7 @@ queue_embed_description: Actualmente hay %d sonidos en la cola de %s
 queue_embed_footer: Página %d de %d
 queue_previous_button_label: Anterior
 queue_next_button_label: Siguiente
+skip_command_description: Para el sonido actual que se está reproduciendo
+skip_command_response: Sonido parado
+shuffle_command_description: Reordena la cola actual de manera aleatoria
+shuffle_command_response: Reordenada la cola de manera aleatoria

--- a/src/test/kotlin/commands/shuffle/ShuffleCommandTest.kt
+++ b/src/test/kotlin/commands/shuffle/ShuffleCommandTest.kt
@@ -24,7 +24,7 @@ class ShuffleCommandTest {
     )
 
     @Test
-    fun `Given interaction When onExecute is called Then execute skip command`() = runTest {
+    fun `Given interaction When onExecute is called Then execute shuffle command`() = runTest {
         // Given
         val mockKord: Kord = mockk {
             every { resources } returns mockk {
@@ -64,7 +64,7 @@ class ShuffleCommandTest {
     }
 
     @Test
-    fun `Given invalid interaction When onExecute is called Then don't execute skip command`() = runTest {
+    fun `Given invalid interaction When onExecute is called Then don't execute shuffle command`() = runTest {
         // Given
         val mockKord: Kord = mockk {
             every { resources } returns mockk {

--- a/src/test/kotlin/commands/shuffle/ShuffleCommandTest.kt
+++ b/src/test/kotlin/commands/shuffle/ShuffleCommandTest.kt
@@ -1,0 +1,105 @@
+package commands.shuffle
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.supplier.EntitySupplyStrategy
+import es.wokis.commands.shuffle.ShuffleCommand
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class ShuffleCommandTest {
+    private val guildQueueService: GuildQueueService = mockk()
+    private val localizationService: LocalizationService = mockk()
+
+    private val shuffleCommand = ShuffleCommand(
+        guildQueueService = guildQueueService,
+        localizationService = localizationService
+    )
+
+    @Test
+    fun `Given interaction When onExecute is called Then execute skip command`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.BULGARIAN
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            every { kord } returns mockKord
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk {
+            justRun { shuffle() }
+        }
+
+        coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
+        every { localizationService.getString(any(), any()) } returns "TestMessage"
+
+        // When
+        shuffleCommand.onExecute(interaction, response)
+
+        // Then
+        verify(exactly = 1) {
+            guildLavaPlayerService.shuffle()
+        }
+    }
+
+    @Test
+    fun `Given invalid interaction When onExecute is called Then don't execute skip command`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.BULGARIAN
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            every { kord } returns mockKord
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk {
+            justRun { shuffle() }
+        }
+        coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } throws IllegalStateException()
+        every { localizationService.getString(any(), any()) } returns "TestMessage"
+
+        // When
+        shuffleCommand.onExecute(interaction, response)
+
+        // Then
+        verify(exactly = 0) {
+            guildLavaPlayerService.shuffle()
+        }
+    }
+}

--- a/src/test/kotlin/commands/skip/SkipCommandTest.kt
+++ b/src/test/kotlin/commands/skip/SkipCommandTest.kt
@@ -1,0 +1,106 @@
+package commands.skip
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.supplier.EntitySupplyStrategy
+import es.wokis.commands.skip.SkipCommand
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class SkipCommandTest {
+
+    private val guildQueueService: GuildQueueService = mockk()
+    private val localizationService: LocalizationService = mockk()
+
+    private val skipCommand = SkipCommand(
+        guildQueueService = guildQueueService,
+        localizationService = localizationService
+    )
+
+    @Test
+    fun `Given interaction When onExecute is called Then execute skip command`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.BULGARIAN
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            every { kord } returns mockKord
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk {
+            justRun { skip() }
+        }
+
+        coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
+        every { localizationService.getString(any(), any()) } returns "TestMessage"
+
+        // When
+        skipCommand.onExecute(interaction, response)
+
+        // Then
+        verify(exactly = 1) {
+            guildLavaPlayerService.skip()
+        }
+    }
+
+    @Test
+    fun `Given invalid interaction When onExecute is called Then don't execute skip command`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.BULGARIAN
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            every { kord } returns mockKord
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk {
+            justRun { skip() }
+        }
+        coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } throws IllegalStateException()
+        every { localizationService.getString(any(), any()) } returns "TestMessage"
+
+        // When
+        skipCommand.onExecute(interaction, response)
+
+        // Then
+        verify(exactly = 0) {
+            guildLavaPlayerService.skip()
+        }
+    }
+}

--- a/src/test/kotlin/services/commands/CommandHandlerServiceTest.kt
+++ b/src/test/kotlin/services/commands/CommandHandlerServiceTest.kt
@@ -8,6 +8,8 @@ import es.wokis.commands.CommandsEnum
 import es.wokis.commands.ComponentsEnum
 import es.wokis.commands.queue.QueueCommand
 import commands.play.PlayCommand
+import es.wokis.commands.shuffle.ShuffleCommand
+import es.wokis.commands.skip.SkipCommand
 import es.wokis.services.commands.CommandHandlerServiceImpl
 import es.wokis.services.localization.LocalizationService
 import io.mockk.*
@@ -18,12 +20,16 @@ class CommandHandlerServiceTest {
 
     private val playCommand: PlayCommand = mockk()
     private val queueCommand: QueueCommand = mockk()
+    private val skipCommand: SkipCommand = mockk()
+    private val shuffleCommand: ShuffleCommand = mockk()
     private val localizationService: LocalizationService = mockk()
 
     private val commandHandlerService = CommandHandlerServiceImpl(
         playCommand = playCommand,
         localizationService = localizationService,
-        queueCommand = queueCommand
+        queueCommand = queueCommand,
+        skipCommand = skipCommand,
+        shuffleCommand = shuffleCommand
     )
 
     @Test
@@ -36,6 +42,8 @@ class CommandHandlerServiceTest {
         }
         justRun { playCommand.onRegisterCommand(any()) }
         justRun { queueCommand.onRegisterCommand(any()) }
+        justRun { skipCommand.onRegisterCommand(any()) }
+        justRun { shuffleCommand.onRegisterCommand(any()) }
 
         // When
         commandHandlerService.onRegisterCommand(commandBuilder)
@@ -85,6 +93,48 @@ class CommandHandlerServiceTest {
         // Then
         coVerify(exactly = 1) {
             queueCommand.onExecute(interaction, response)
+        }
+    }
+
+    @Test
+    fun `Given skip command When onExecute is called Then execute SkipCommand`() = runTest {
+        // Given
+        val commandName = CommandsEnum.SKIP.commandName
+        val interaction: ChatInputCommandInteraction = mockk {
+            every { command } returns mockk {
+                every { rootName } returns commandName
+            }
+        }
+        val response: DeferredPublicMessageInteractionResponseBehavior = mockk()
+        coJustRun { skipCommand.onExecute(any(), any()) }
+
+        // When
+        commandHandlerService.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            skipCommand.onExecute(interaction, response)
+        }
+    }
+
+    @Test
+    fun `Given shuffle command When onExecute is called Then execute ShuffleCommand`() = runTest {
+        // Given
+        val commandName = CommandsEnum.SHUFFLE.commandName
+        val interaction: ChatInputCommandInteraction = mockk {
+            every { command } returns mockk {
+                every { rootName } returns commandName
+            }
+        }
+        val response: DeferredPublicMessageInteractionResponseBehavior = mockk()
+        coJustRun { shuffleCommand.onExecute(any(), any()) }
+
+        // When
+        shuffleCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            shuffleCommand.onExecute(interaction, response)
         }
     }
 


### PR DESCRIPTION
Solves #27.

## 📋 Changelist Summary
- Created skip command
- Created shuffle command

## 💬 Description
Created skip command to skip current playing track. This command will try to play the next track on the queue, if there's any left. If there's none, the bot will be disconnected automatically after the configured timeout.

Also, created shuffle command to randomly shuffle the current queue of the Guild.