### PR TITLE
Solved bot sending ephemeral message to acknowledge action

### DIFF
--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -73,7 +73,7 @@ class Bot(
         }
 
         bot.on<ButtonInteractionCreateEvent> {
-            interaction.deferEphemeralResponse().delete()
+            interaction.deferPublicMessageUpdate()
             commandHandlerService.onInteract(interaction)
         }
     }


### PR DESCRIPTION
Solves #69.

## 📋 Changelist Summary
Bot updates message without ephemeral being sent.

## 💬 Description
Changed `interaction.deferEphemeralResponse().delete()` which served as interaction acknowledge when the bot received a button interaction. Now, we will send the acknowledgement by editing the original message using `interaction.deferPublicMessageUpdate()`.

## 🐞 Steps to reproduce bug
Steps to reproduce the behavior:
1. Use /queue with more than 30 sounds
2. Click next
3. A ephemeral message will be shown