### PR TITLE
Fixed frame pathing error by adding a timeout to provide function

### DIFF
--- a/src/main/kotlin/commands/player/PlayerCommons.kt
+++ b/src/main/kotlin/commands/player/PlayerCommons.kt
@@ -139,9 +139,9 @@ private fun List<AudioTrack>.getDisplayQueue(localizationService: LocalizationSe
     val thirdTrack = getOrNull(2)
     val queueRemaining = (size - 3).takeIf { it > 0 }
     val duration = filterNot { it.info.isStream || it.duration == DURATION_MS_UNKNOWN }.sumOf { it.duration }.toDisplayDuration()
-    return firstTrack?.getDisplayNameAndDuration()
-        ?.plus(secondTrack?.let { "\n${it.getDisplayNameAndDuration()}" }.orEmpty())
-        ?.plus(thirdTrack?.let { "\n${it.getDisplayNameAndDuration()}" }.orEmpty())
+    return firstTrack?.getDisplayNameAndDuration(localizationService, locale)
+        ?.plus(secondTrack?.let { "\n${it.getDisplayNameAndDuration(localizationService, locale)}" }.orEmpty())
+        ?.plus(thirdTrack?.let { "\n${it.getDisplayNameAndDuration(localizationService, locale)}" }.orEmpty())
         ?.plus(
             queueRemaining?.let {
                 "\n".plus(
@@ -164,7 +164,14 @@ private fun List<AudioTrack>.getDisplayQueue(localizationService: LocalizationSe
         ).orEmpty()
 }
 
-private fun AudioTrack.getDisplayNameAndDuration() = "${getDisplayTrackName()} (${duration.toDisplayDuration()})"
+private fun AudioTrack.getDisplayNameAndDuration(localizationService: LocalizationService, locale: Locale): String {
+    val displayDuration = if (duration != DURATION_MS_UNKNOWN) {
+        duration.toDisplayDuration()
+    } else {
+        localizationService.getString(LocalizationKeys.PLAYER_TRACK_DURATION_STREAM, locale)
+    }
+    return "${getDisplayTrackName()} ($displayDuration)"
+}
 
 private fun Long.toDisplayDuration() = toDuration(DurationUnit.MILLISECONDS).toComponents { hours, minutes, seconds, _ ->
     "%02d:%02d:%02d".format(hours, minutes, seconds)

--- a/src/main/kotlin/commands/player/PlayerCommons.kt
+++ b/src/main/kotlin/commands/player/PlayerCommons.kt
@@ -66,11 +66,11 @@ fun AbstractMessageModifyBuilder.createPlayerEmbed(
                 name = localizationService.getString(key = LocalizationKeys.PLAYER_SERVER_QUEUE, locale = locale)
                 value = queue.getDisplayQueue(localizationService, locale)
             }
-        } else {
+        } else if (currentTrack == null) {
             description = localizationService.getString(key = LocalizationKeys.PLAYER_SERVER_QUEUE_EMPTY, locale = locale)
         }
     }
-    components = if (queue.isNotEmpty() && currentTrack != null) {
+    components = if (queue.isNotEmpty() || currentTrack != null) {
         createPlayerComponents(
             localizationService = localizationService,
             locale = locale,
@@ -138,7 +138,7 @@ private fun List<AudioTrack>.getDisplayQueue(localizationService: LocalizationSe
     val secondTrack = getOrNull(1)
     val thirdTrack = getOrNull(2)
     val queueRemaining = (size - 3).takeIf { it > 0 }
-    val duration = sumOf { it.duration }.toDisplayDuration()
+    val duration = filterNot { it.info.isStream || it.duration == DURATION_MS_UNKNOWN }.sumOf { it.duration }.toDisplayDuration()
     return firstTrack?.getDisplayNameAndDuration()
         ?.plus(secondTrack?.let { "\n${it.getDisplayNameAndDuration()}" }.orEmpty())
         ?.plus(thirdTrack?.let { "\n${it.getDisplayNameAndDuration()}" }.orEmpty())

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -18,7 +18,6 @@ import dev.kord.core.entity.channel.MessageChannel
 import dev.kord.gateway.retry.LinearRetry
 import dev.kord.voice.AudioFrame
 import dev.kord.voice.VoiceConnection
-import dev.kord.voice.gateway.Close
 import es.wokis.commands.player.createPlayerEmbed
 import es.wokis.dispatchers.AppDispatchers
 import es.wokis.localization.LocalizationKeys
@@ -106,21 +105,6 @@ class GuildLavaPlayerService(
                 updateSeekChannel.send(Unit)
             } ?: sendNowPlayingMessage(locale, track, voiceChannelName)
         }
-    }
-
-    override fun onTrackStuck(player: AudioPlayer?, track: AudioTrack?, thresholdMs: Long) {
-        super.onTrackStuck(player, track, thresholdMs)
-        Log.warning("Track stuck: $track")
-    }
-
-    override fun onTrackStuck(
-        player: AudioPlayer?,
-        track: AudioTrack?,
-        thresholdMs: Long,
-        stackTrace: Array<out StackTraceElement>?
-    ) {
-        super.onTrackStuck(player, track, thresholdMs, stackTrace)
-        Log.warning("Track stuck: $track")
     }
 
     fun loadAndPlay(url: String) {
@@ -351,13 +335,6 @@ class GuildLavaPlayerService(
                 selfDeaf = true
             }.also {
                 connectingToVoiceChannel = false
-                coroutineScope.launch {
-                    it.voiceGateway.events.collect { event ->
-                        if (event is Close) {
-                            Log.warning("Voice connection closed: $event")
-                        }
-                    }
-                }
             }
         }
     }
@@ -400,7 +377,7 @@ class GuildLavaPlayerService(
                     )
                 }
             } catch (t: Throwable) {
-                Log.error("There's been an error trying to update the embed message", t)
+                Log.error("There's been an error trying to update the embed message on $guildName", t)
             }
         }
     }

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -385,15 +385,19 @@ class GuildLavaPlayerService(
     private suspend fun updatePlayerEmbed() {
         playerMessage?.let {
             val guildName = textChannel.data.guildId.value?.let { guildId -> textChannel.kord.getGuild(guildId) }?.name.orEmpty()
-            it.edit {
-                createPlayerEmbed(
-                    guildName = guildName,
-                    localizationService = localizationService,
-                    locale = voiceChannel.getLocale(),
-                    currentTrack = player.playingTrack,
-                    queue = queue,
-                    isPaused = player.isPaused
-                )
+            try {
+                it.edit {
+                    createPlayerEmbed(
+                        guildName = guildName,
+                        localizationService = localizationService,
+                        locale = voiceChannel.getLocale(),
+                        currentTrack = player.playingTrack,
+                        queue = queue,
+                        isPaused = player.isPaused
+                    )
+                }
+            } catch (t: Throwable) {
+                Log.error("There's been an error trying to update the embed message", t)
             }
         }
     }

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -69,6 +69,7 @@ class GuildLavaPlayerService(
     private var playerMessage: Message? = null
     private var seekTimerJob: Job? = null
     private val updateSeekChannel = Channel<Unit>(Channel.CONFLATED)
+    private var frameTimeOut = 20L
 
     init {
         coroutineScope.launch {
@@ -167,10 +168,12 @@ class GuildLavaPlayerService(
     fun isPaused(): Boolean = player.isPaused
 
     fun resume() {
+        frameTimeOut = 20L
         player.isPaused = false
     }
 
     fun pause() {
+        frameTimeOut = 0L
         player.isPaused = true
     }
 
@@ -344,7 +347,7 @@ class GuildLavaPlayerService(
         if (voiceConnection == null && connectingToVoiceChannel.not()) {
             connectingToVoiceChannel = true
             voiceConnection = voiceChannel.connect {
-                audioProvider { AudioFrame.fromData(player.provide(20L, TimeUnit.MILLISECONDS)?.data) }
+                audioProvider { AudioFrame.fromData(player.provide(frameTimeOut, TimeUnit.MILLISECONDS)?.data) }
                 selfDeaf = true
             }.also {
                 connectingToVoiceChannel = false


### PR DESCRIPTION
<!-- Change #issue with the issue it is related, if it applies -->
Solves #77.

## 📋 Changelist Summary
Fixed frame pathing error by adding a timeout to provide function

## 💬 Description
Randomly, the bot stops playing current track. This happened after we deployed to the server with the beta/debug .jar. This may be because lavaplayer cannot provide each frame correctly, getting stuck as it is trying to provide the same frame without a timeout, or because Discord closes the voice gateway/websocket.

It seems that it can be fixed if a timeout is added to lavaplayer's provide function. Currently, it works with a 20ms timeout. This timeout shouldn't be necessary but, as of right now, if no timeout is provided and an exception occurs, Lavaplayer's Default player can, and will, block the current thread, blocking future frames.

See [AudioFrameProviderTools implementation](https://github.com/lavalink-devs/lavaplayer/blob/ea72ae81b4992147758aa1e462b6f283db237534/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/playback/AudioFrameProviderTools.java#L11).
