### PR TITLE
Implement Tidal support

### DIFF
--- a/src/main/kotlin/services/config/ConfigBO.kt
+++ b/src/main/kotlin/services/config/ConfigBO.kt
@@ -18,7 +18,9 @@ data class Config(
     @SerialName("deezer")
     val deezer: DeezerConfig,
     @SerialName("spotify")
-    val spotify: SpotifyConfig
+    val spotify: SpotifyConfig,
+    @SerialName("tidal")
+    val tidal: TidalConfig
 )
 
 @Serializable
@@ -77,4 +79,14 @@ data class SpotifyConfig(
     val clientSecret: String,
     @SerialName("custom_endpoint")
     val customEndpoint: String
+)
+
+@Serializable
+data class TidalConfig(
+    @SerialName("enabled")
+    val enabled: Boolean,
+    @SerialName("country_code")
+    val countryCode: String,
+    @SerialName("token")
+    val token: String
 )

--- a/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
+++ b/src/main/kotlin/services/lavaplayer/AudioPlayerManagerProvider.kt
@@ -4,6 +4,7 @@ import com.github.topi314.lavasrc.deezer.DeezerAudioSourceManager
 import com.github.topi314.lavasrc.flowerytts.FloweryTTSSourceManager
 import com.github.topi314.lavasrc.mirror.DefaultMirroringAudioTrackResolver
 import com.github.topi314.lavasrc.spotify.SpotifySourceManager
+import com.github.topi314.lavasrc.tidal.TidalSourceManager
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers
@@ -66,6 +67,16 @@ class AudioPlayerManagerProvider(
                         setPreferAnonymousToken(false)
                     }
                 }
+            )
+        }
+        if (configService.config.tidal.enabled) {
+            this.registerSourceManager(
+                TidalSourceManager(
+                    configService.config.tidal.countryCode,
+                    { this },
+                    DefaultMirroringAudioTrackResolver(null),
+                    configService.config.tidal.token
+                )
             )
         }
         this.registerSourceManager(

--- a/src/main/resources/template/config_template.json
+++ b/src/main/resources/template/config_template.json
@@ -29,5 +29,10 @@
     "client_id": "",
     "client_secret": "",
     "custom_endpoint": ""
+  },
+  "tidal": {
+    "enabled": false,
+    "country_code": "ES",
+    "token": ""
   }
 }

--- a/src/test/kotlin/services/lavaplayer/AudioPlayerManagerProviderTest.kt
+++ b/src/test/kotlin/services/lavaplayer/AudioPlayerManagerProviderTest.kt
@@ -17,8 +17,16 @@ class AudioPlayerManagerProviderTest {
     fun `When createAudioPlayerManager is called Then return DefaultAudioPlayerManager`() {
         // Given
         every { configService.config.youtube.oauth2Token } returns null
-        every { configService.config.deezer.enabled } returns false
-        every { configService.config.spotify.enabled } returns false
+        every { configService.config.deezer.enabled } returns true
+        every { configService.config.deezer.masterDecryptionKey } returns "master_key"
+        every { configService.config.deezer.arlToken } returns "altoke"
+        every { configService.config.spotify.enabled } returns true
+        every { configService.config.spotify.clientId } returns "client_id"
+        every { configService.config.spotify.clientSecret } returns "client_secret"
+        every { configService.config.spotify.customEndpoint } returns ""
+        every { configService.config.tidal.enabled } returns true
+        every { configService.config.tidal.countryCode } returns "ES"
+        every { configService.config.tidal.token } returns "altoke"
         every { configService.config.youtube.poToken } returns null
         every { configService.config.youtube.visitorData } returns null
         every { configService.config.youtube.remoteCipherUrl } returns null


### PR DESCRIPTION
<!-- Change #issue with the issue it is related, if it applies -->
Solves #87

## 📋 Changelist Summary
Add Tidal support

## 💬 Description
Implement Tidal support with LavaSrc. A token is needed, it can be generated using tidal_auth.py from https://github.com/uimaxbai/hifi-api (the token is `client_ID` from the generated json)