### PR TITLE
Fix markdown link titles with emojis or URLs and update to Java 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,7 @@ sonar {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 tasks.register("generateLangClass") {

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -30,7 +30,7 @@ import es.wokis.utils.Log
 import es.wokis.utils.createCoroutineScope
 import es.wokis.utils.getDisplayTrackName
 import es.wokis.utils.getLocale
-import es.wokis.utils.toMarkdownLinkEmojiAware
+import es.wokis.utils.toSanitizedMarkdownLink
 import es.wokis.utils.isValidUrl
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -179,7 +179,7 @@ class GuildLavaPlayerService(
                 localizationService.getStringFormat(
                     key = LocalizationKeys.ADDED_TRACK_TO_QUEUE_WITH_LINK,
                     locale = locale,
-                    arguments = arrayOf(radioName.toMarkdownLinkEmojiAware(radioUrl))
+                    arguments = arrayOf(radioName.toSanitizedMarkdownLink(radioUrl))
                 )
             )
             queue(listOf(it))
@@ -440,7 +440,7 @@ class GuildLavaPlayerService(
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_SONGS_TO_QUEUE_WITH_LINK else LocalizationKeys.ADDED_SONGS_TO_QUEUE_WITH_LINK,
                         locale = locale,
-                        arguments = arrayOf(playlist.name.toMarkdownLinkEmojiAware(playlistUrl), playlist.tracks.size)
+                        arguments = arrayOf(playlist.name.toSanitizedMarkdownLink(playlistUrl), playlist.tracks.size)
                     )
                 } else {
                     localizationService.getStringFormat(
@@ -463,7 +463,7 @@ class GuildLavaPlayerService(
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_TO_QUEUE_WITH_LINK else LocalizationKeys.ADDED_TRACK_TO_QUEUE_WITH_LINK,
                         locale = locale,
-                        arguments = arrayOf(currentTrack.getDisplayTrackName().toMarkdownLinkEmojiAware(track.info.uri))
+                        arguments = arrayOf(currentTrack.getDisplayTrackName().toSanitizedMarkdownLink(track.info.uri))
                     )
                 } else {
                     localizationService.getStringFormat(

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -30,6 +30,7 @@ import es.wokis.utils.Log
 import es.wokis.utils.createCoroutineScope
 import es.wokis.utils.getDisplayTrackName
 import es.wokis.utils.getLocale
+import es.wokis.utils.toMarkdownLinkEmojiAware
 import es.wokis.utils.isValidUrl
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -178,7 +179,7 @@ class GuildLavaPlayerService(
                 localizationService.getStringFormat(
                     key = LocalizationKeys.ADDED_TRACK_TO_QUEUE_WITH_LINK,
                     locale = locale,
-                    arguments = arrayOf(radioName, radioUrl)
+                    arguments = arrayOf(radioName.toMarkdownLinkEmojiAware(radioUrl))
                 )
             )
             queue(listOf(it))
@@ -439,7 +440,7 @@ class GuildLavaPlayerService(
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_SONGS_TO_QUEUE_WITH_LINK else LocalizationKeys.ADDED_SONGS_TO_QUEUE_WITH_LINK,
                         locale = locale,
-                        arguments = arrayOf(playlist.name, playlistUrl, playlist.tracks.size)
+                        arguments = arrayOf(playlist.name.toMarkdownLinkEmojiAware(playlistUrl), playlist.tracks.size)
                     )
                 } else {
                     localizationService.getStringFormat(
@@ -462,7 +463,7 @@ class GuildLavaPlayerService(
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_TO_QUEUE_WITH_LINK else LocalizationKeys.ADDED_TRACK_TO_QUEUE_WITH_LINK,
                         locale = locale,
-                        arguments = arrayOf(currentTrack.getDisplayTrackName(), track.info.uri)
+                        arguments = arrayOf(currentTrack.getDisplayTrackName().toMarkdownLinkEmojiAware(track.info.uri))
                     )
                 } else {
                     localizationService.getStringFormat(

--- a/src/main/kotlin/utils/StringUtils.kt
+++ b/src/main/kotlin/utils/StringUtils.kt
@@ -4,7 +4,9 @@ import java.net.URLEncoder
 
 private const val URL_ENCODED_SPACE = "+"
 private const val SPACE_UTF_8 = "%20"
-private val EMOJI_COMBINATION_REGEX = Regex("(\\p{IsEmoji_Presentation}|\\p{IsEmoji_Modifier}|\\p{IsEmoji_Modifier_Base}|\\p{IsEmoji_Component}|\\p{IsExtended_Pictographic})+")
+private const val EMOJI_REGEX_PATTERN = "(\\p{IsEmoji_Presentation}|\\p{IsEmoji_Modifier}|\\p{IsEmoji_Modifier_Base}|\\p{IsEmoji_Component}|\\p{IsExtended_Pictographic})+"
+private const val URL_PATTERN_REGEX_PATTERN = "https?://[^\\s]+"
+private val PROBLEMATIC_MARKDOWN_PATTERNS_REGEX = Regex("$EMOJI_REGEX_PATTERN|$URL_PATTERN_REGEX_PATTERN")
 
 fun String.takeIfNotEmpty() = takeIf { it.isNotEmpty() }
 
@@ -16,18 +18,18 @@ fun String.asEncodedUrl() = URLEncoder.encode(this, Charsets.UTF_8).replace(URL_
 fun String.takeAtMost(maxLength: Int) = if (length < maxLength) this else this.take(maxLength - 2).trim().plus("…")
 
 /**
- * Creates a markdown link with emojis excluded from the link text.
- * Discord doesn't render markdown links correctly when emojis are inside the link brackets,
- * so this function splits the text around emojis to create multiple links.
+ * Creates a markdown link with special characters (emojis, URLs) excluded from the link text.
+ * Discord doesn't render markdown links correctly when emojis or http/https URLs are inside the link brackets,
+ * so this function splits the text around these elements to create multiple links.
  *
  * Example: "I love the 🍆 emoji" with url "https://example.com" becomes
  * `[I love the ](https://example.com)🍆[ emoji](https://example.com)`
  */
-fun String.toMarkdownLinkEmojiAware(url: String): String {
+fun String.toSanitizedMarkdownLink(url: String): String {
     val originalText = this
     return buildString {
         var lastEnd = 0
-        EMOJI_COMBINATION_REGEX.findAll(originalText).forEach { match ->
+        PROBLEMATIC_MARKDOWN_PATTERNS_REGEX.findAll(originalText).forEach { match ->
             val textBefore = originalText.substring(lastEnd, match.range.first)
             if (textBefore.isNotEmpty()) {
                 append("[$textBefore]($url)")

--- a/src/main/kotlin/utils/StringUtils.kt
+++ b/src/main/kotlin/utils/StringUtils.kt
@@ -4,6 +4,7 @@ import java.net.URLEncoder
 
 private const val URL_ENCODED_SPACE = "+"
 private const val SPACE_UTF_8 = "%20"
+private val EMOJI_COMBINATION_REGEX = Regex("(\\p{IsEmoji_Presentation}|\\p{IsEmoji_Modifier}|\\p{IsEmoji_Modifier_Base}|\\p{IsEmoji_Component}|\\p{IsExtended_Pictographic})+")
 
 fun String.takeIfNotEmpty() = takeIf { it.isNotEmpty() }
 
@@ -13,3 +14,31 @@ fun String.isValidUrl(): Boolean =
 fun String.asEncodedUrl() = URLEncoder.encode(this, Charsets.UTF_8).replace(URL_ENCODED_SPACE, SPACE_UTF_8)
 
 fun String.takeAtMost(maxLength: Int) = if (length < maxLength) this else this.take(maxLength - 2).trim().plus("…")
+
+/**
+ * Creates a markdown link with emojis excluded from the link text.
+ * Discord doesn't render markdown links correctly when emojis are inside the link brackets,
+ * so this function splits the text around emojis to create multiple links.
+ *
+ * Example: "I love the 🍆 emoji" with url "https://example.com" becomes
+ * `[I love the ](https://example.com)🍆[ emoji](https://example.com)`
+ */
+fun String.toMarkdownLinkEmojiAware(url: String): String {
+    val originalText = this
+    return buildString {
+        var lastEnd = 0
+        EMOJI_COMBINATION_REGEX.findAll(originalText).forEach { match ->
+            val textBefore = originalText.substring(lastEnd, match.range.first)
+            if (textBefore.isNotEmpty()) {
+                append("[$textBefore]($url)")
+            }
+            append(match.value)
+            lastEnd = match.range.last + 1
+        }
+
+        val remainingText = originalText.substring(lastEnd)
+        if (remainingText.isNotEmpty()) {
+            append("[$remainingText]($url)")
+        }
+    }
+}

--- a/src/main/resources/lang/lang.yml
+++ b/src/main/resources/lang/lang.yml
@@ -6,9 +6,9 @@ unknown_command: Unknown or unregistered command, command name %s
 now_playing: 🎶 Playing %s in %s
 no_matches: No matches found for %s
 added_track_to_queue: Added %s to the queue
-added_track_to_queue_with_link: Added [%s](%s) to the queue
+added_track_to_queue_with_link: Added %s to the queue
 added_songs_to_queue: Added %s (%d tracks) to the queue
-added_songs_to_queue_with_link: Added [%s](%s) (%d tracks) to the queue
+added_songs_to_queue_with_link: Added %s (%d tracks) to the queue
 found_track_list: Found track list %s with %d tracks
 load_failed: Load failed, %s
 message_processor_invalid_link: I've received an invalid link. The original one was %s
@@ -83,9 +83,9 @@ player_shown_on_existing_channel: Created player on <#%s>
 next_command_description: Adds a track to the next position in the queue
 next_command_input_description: Track URL to add next or search term to move existing track
 next_added_to_queue: Added %s to the next position in queue
-next_added_to_queue_with_link: Added [%s](%s) to the next position in queue
+next_added_to_queue_with_link: Added %s to the next position in queue
 next_added_songs_to_queue: Added %s (%d tracks) to the next position in queue
-next_added_songs_to_queue_with_link: Added [%s](%s) (%d tracks) to the next position in queue
+next_added_songs_to_queue_with_link: Added %s (%d tracks) to the next position in queue
 next_track_moved: Moved %s to the next position in queue
 next_track_not_found: No track found matching "%s" in the queue
 next_empty_queue: The queue is empty, cannot search for tracks

--- a/src/main/resources/lang/lang_es-ES.yml
+++ b/src/main/resources/lang/lang_es-ES.yml
@@ -6,9 +6,9 @@ unknown_command: Comando desconocido o sin registrar, nombre del comando %s
 now_playing: 🎶 Reproduciendo %s en %s
 no_matches: No se han encontrado resultados para %s
 added_track_to_queue: Añadido %s a la cola
-added_track_to_queue_with_link: Añadido [%s](%s) a la cola
+added_track_to_queue_with_link: Añadido %s a la cola
 added_songs_to_queue: Añadido %s (%d canciones) a la cola
-added_songs_to_queue_with_link: Añadido [%s](%s) (%d canciones) a la cola
+added_songs_to_queue_with_link: Añadido %s (%d canciones) a la cola
 found_track_list: Encontrada la lista de reproducción %s con %d canciones
 load_failed: Error al cargar, %s
 message_processor_invalid_link: He recibido un enlace incorrecto. El original era %s
@@ -83,9 +83,9 @@ player_shown_on_existing_channel: Reproductor creado en <#%s>
 next_command_description: Añade una pista a la siguiente posición en la cola
 next_command_input_description: URL de la pista para añadir a continuación o término de búsqueda para mover una pista existente
 next_added_to_queue: Añadido %s a la siguiente posición en la cola
-next_added_to_queue_with_link: Añadido [%s](%s) a la siguiente posición en la cola
+next_added_to_queue_with_link: Añadido %s a la siguiente posición en la cola
 next_added_songs_to_queue: Añadido %s (%d pistas) a la siguiente posición en la cola
-next_added_songs_to_queue_with_link: Añadido [%s](%s) (%d pistas) a la siguiente posición en la cola
+next_added_songs_to_queue_with_link: Añadido %s (%d pistas) a la siguiente posición en la cola
 next_track_moved: Movido %s a la siguiente posición en la cola
 next_track_not_found: No se encontró ninguna pista que coincida con "%s" en la cola
 next_empty_queue: La cola está vacía, no se pueden buscar pistas

--- a/src/test/kotlin/utils/StringUtilsTest.kt
+++ b/src/test/kotlin/utils/StringUtilsTest.kt
@@ -1,5 +1,6 @@
 package utils
 
+import es.wokis.utils.toMarkdownLinkEmojiAware
 import es.wokis.utils.isValidUrl
 import es.wokis.utils.takeIfNotEmpty
 import org.junit.jupiter.api.Test
@@ -66,5 +67,135 @@ class StringUtilsTest {
 
         // Then
         assertFalse(actual)
+    }
+
+    @Test
+    fun `Given text without emoji When createMarkdownLinkWithEmojis is called Then return simple markdown link`() {
+        // Given
+        val text = "Hello World"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then
+        assertEquals("[Hello World](https://example.com)", actual)
+    }
+
+    @Test
+    fun `Given text with emoji at start When toMarkdownLinkEmojiAware is called Then emoji is not in link`() {
+        // Given
+        val text = "🎵 Music Track"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then
+        assertEquals("🎵[ Music Track](https://example.com)", actual)
+    }
+
+    @Test
+    fun `Given text with emoji at end When toMarkdownLinkEmojiAware is called Then emoji is not in link`() {
+        // Given
+        val text = "Music Track 🎵"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then
+        assertEquals("[Music Track ](https://example.com)🎵", actual)
+    }
+
+    @Test
+    fun `Given text with emoji in middle When toMarkdownLinkEmojiAware is called Then splits into two links`() {
+        // Given
+        val text = "Music 🎵 Track"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then
+        assertEquals("[Music ](https://example.com)🎵[ Track](https://example.com)", actual)
+    }
+
+    @Test
+    fun `Given text with multiple emojis When toMarkdownLinkEmojiAware is called Then handles all emojis`() {
+        // Given
+        val text = "🎵 Music 🎶 Track 🔊"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then
+        assertEquals("🎵[ Music ](https://example.com)🎶[ Track ](https://example.com)🔊", actual)
+    }
+
+    @Test
+    fun `Given only emojis When toMarkdownLinkEmojiAware is called Then returns emojis without links`() {
+        // Given
+        val text = "🎵🎶🔊"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then
+        assertEquals("🎵🎶🔊", actual)
+    }
+
+    @Test
+    fun `Given empty string When toMarkdownLinkEmojiAware is called Then return empty string`() {
+        // Given
+        val text = ""
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then
+        assertEquals("", actual)
+    }
+
+    @Test
+    fun `Given text with ZWJ sequence emoji When toMarkdownLinkEmojiAware is called Then handles combined emoji as one`() {
+        // Given - 👨🏻‍💻 (Man Technologist: Light Skin Tone) is a ZWJ sequence
+        val text = "Dev 👨🏻‍💻 Coding"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then - The entire ZWJ sequence should be treated as one emoji
+        assertEquals("[Dev ](https://example.com)👨🏻‍💻[ Coding](https://example.com)", actual)
+    }
+
+    @Test
+    fun `Given text with skin tone modifier When toMarkdownLinkEmojiAware is called Then handles as one emoji`() {
+        // Given - 👋🏽 (Waving Hand: Medium Skin Tone)
+        val text = "Hello 👋🏽 World"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then - Base emoji + skin tone should be treated as one emoji
+        assertEquals("[Hello ](https://example.com)👋🏽[ World](https://example.com)", actual)
+    }
+
+    @Test
+    fun `Given text with flag emoji When toMarkdownLinkEmojiAware is called Then handles flag as one emoji`() {
+        // Given - 🇺🇸 (US Flag) is two regional indicator symbols
+        val text = "USA 🇺🇸 America"
+        val url = "https://example.com"
+
+        // When
+        val actual = text.toMarkdownLinkEmojiAware(url)
+
+        // Then - Flag should be treated as one emoji
+        assertEquals("[USA ](https://example.com)🇺🇸[ America](https://example.com)", actual)
     }
 }

--- a/src/test/kotlin/utils/StringUtilsTest.kt
+++ b/src/test/kotlin/utils/StringUtilsTest.kt
@@ -1,8 +1,8 @@
 package utils
 
-import es.wokis.utils.toMarkdownLinkEmojiAware
 import es.wokis.utils.isValidUrl
 import es.wokis.utils.takeIfNotEmpty
+import es.wokis.utils.toMarkdownLinkEmojiAware
 import org.junit.jupiter.api.Test
 import kotlin.test.*
 

--- a/src/test/kotlin/utils/StringUtilsTest.kt
+++ b/src/test/kotlin/utils/StringUtilsTest.kt
@@ -2,7 +2,7 @@ package utils
 
 import es.wokis.utils.isValidUrl
 import es.wokis.utils.takeIfNotEmpty
-import es.wokis.utils.toMarkdownLinkEmojiAware
+import es.wokis.utils.toSanitizedMarkdownLink
 import org.junit.jupiter.api.Test
 import kotlin.test.*
 
@@ -70,130 +70,130 @@ class StringUtilsTest {
     }
 
     @Test
-    fun `Given text without emoji When createMarkdownLinkWithEmojis is called Then return simple markdown link`() {
+    fun `Given text without emoji When toSanitizedMarkdownLink is called Then return simple markdown link`() {
         // Given
         val text = "Hello World"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then
         assertEquals("[Hello World](https://example.com)", actual)
     }
 
     @Test
-    fun `Given text with emoji at start When toMarkdownLinkEmojiAware is called Then emoji is not in link`() {
+    fun `Given text with emoji at start When toSanitizedMarkdownLink is called Then emoji is not in link`() {
         // Given
         val text = "🎵 Music Track"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then
         assertEquals("🎵[ Music Track](https://example.com)", actual)
     }
 
     @Test
-    fun `Given text with emoji at end When toMarkdownLinkEmojiAware is called Then emoji is not in link`() {
+    fun `Given text with emoji at end When toSanitizedMarkdownLink is called Then emoji is not in link`() {
         // Given
         val text = "Music Track 🎵"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then
         assertEquals("[Music Track ](https://example.com)🎵", actual)
     }
 
     @Test
-    fun `Given text with emoji in middle When toMarkdownLinkEmojiAware is called Then splits into two links`() {
+    fun `Given text with emoji in middle When toSanitizedMarkdownLink is called Then splits into two links`() {
         // Given
         val text = "Music 🎵 Track"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then
         assertEquals("[Music ](https://example.com)🎵[ Track](https://example.com)", actual)
     }
 
     @Test
-    fun `Given text with multiple emojis When toMarkdownLinkEmojiAware is called Then handles all emojis`() {
+    fun `Given text with multiple emojis When toSanitizedMarkdownLink is called Then handles all emojis`() {
         // Given
         val text = "🎵 Music 🎶 Track 🔊"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then
         assertEquals("🎵[ Music ](https://example.com)🎶[ Track ](https://example.com)🔊", actual)
     }
 
     @Test
-    fun `Given only emojis When toMarkdownLinkEmojiAware is called Then returns emojis without links`() {
+    fun `Given only emojis When toSanitizedMarkdownLink is called Then returns emojis without links`() {
         // Given
         val text = "🎵🎶🔊"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then
         assertEquals("🎵🎶🔊", actual)
     }
 
     @Test
-    fun `Given empty string When toMarkdownLinkEmojiAware is called Then return empty string`() {
+    fun `Given empty string When toSanitizedMarkdownLink is called Then return empty string`() {
         // Given
         val text = ""
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then
         assertEquals("", actual)
     }
 
     @Test
-    fun `Given text with ZWJ sequence emoji When toMarkdownLinkEmojiAware is called Then handles combined emoji as one`() {
+    fun `Given text with ZWJ sequence emoji When toSanitizedMarkdownLink is called Then handles combined emoji as one`() {
         // Given - 👨🏻‍💻 (Man Technologist: Light Skin Tone) is a ZWJ sequence
         val text = "Dev 👨🏻‍💻 Coding"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then - The entire ZWJ sequence should be treated as one emoji
         assertEquals("[Dev ](https://example.com)👨🏻‍💻[ Coding](https://example.com)", actual)
     }
 
     @Test
-    fun `Given text with skin tone modifier When toMarkdownLinkEmojiAware is called Then handles as one emoji`() {
+    fun `Given text with skin tone modifier When toSanitizedMarkdownLink is called Then handles as one emoji`() {
         // Given - 👋🏽 (Waving Hand: Medium Skin Tone)
         val text = "Hello 👋🏽 World"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then - Base emoji + skin tone should be treated as one emoji
         assertEquals("[Hello ](https://example.com)👋🏽[ World](https://example.com)", actual)
     }
 
     @Test
-    fun `Given text with flag emoji When toMarkdownLinkEmojiAware is called Then handles flag as one emoji`() {
+    fun `Given text with flag emoji When toSanitizedMarkdownLink is called Then handles flag as one emoji`() {
         // Given - 🇺🇸 (US Flag) is two regional indicator symbols
         val text = "USA 🇺🇸 America"
         val url = "https://example.com"
 
         // When
-        val actual = text.toMarkdownLinkEmojiAware(url)
+        val actual = text.toSanitizedMarkdownLink(url)
 
         // Then - Flag should be treated as one emoji
         assertEquals("[USA ](https://example.com)🇺🇸[ America](https://example.com)", actual)


### PR DESCRIPTION
<!-- Change #issue with the issue it is related, if it applies -->
Solves #102 

## 📋 Changelist Summary
- Fix links with emojis or URLs
- Update to Java 21

## 💬 Description
Discord doesn't render markdown links correctly when emojis or http/https URLs are inside the link brackets (the link title), so a new function has been created that splits the text around those problematic parts to create multiple links.

For example, the text "I love the 🍆 emoji" with url https://example.com becomes `[I love the ](https://example.com)🍆[ emoji](https://example.com)`

Project has been updated to Java 21 in order to use the new emoji regex patterns.