### PR TITLE
Created /locale command to set locale of a guild

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -18,6 +18,6 @@ suspend fun main() {
 
 fun initKoin() {
     startKoin {
-        modules(botModule, servicesModule, commandModule, remoteModule, domainModule)
+        modules(botModule, repositoryModule, servicesModule, commandModule, remoteModule, domainModule)
     }
 }

--- a/src/main/kotlin/commands/CommandName.kt
+++ b/src/main/kotlin/commands/CommandName.kt
@@ -12,6 +12,7 @@ sealed class CommandName(val commandName: String) {
     data object Reconnect : CommandName("reconnect")
     data object Next : CommandName("next")
     data object Disconnect : CommandName("disconnect")
+    data object Locale : CommandName("locale")
     data object Radio : CommandName("radio") {
         data object Play : CommandName("play")
         data object List : CommandName("list")

--- a/src/main/kotlin/commands/commons/PaginatedEmbedUtils.kt
+++ b/src/main/kotlin/commands/commons/PaginatedEmbedUtils.kt
@@ -4,6 +4,7 @@ import dev.kord.common.Color
 import dev.kord.common.Locale
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.DiscordPartialEmoji
+import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.component.ActionRowBuilder
 import dev.kord.rest.builder.component.MessageComponentBuilder
 import dev.kord.rest.builder.message.embed
@@ -13,8 +14,9 @@ import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.utils.takeIfNotEmpty
 
-fun AbstractMessageModifyBuilder.createPaginatedEmbedMessage(
-    locale: Locale,
+suspend fun AbstractMessageModifyBuilder.createPaginatedEmbedMessage(
+    guildId: Snowflake?,
+    discordLocale: Locale?,
     localizationService: LocalizationService,
     title: String,
     description: String?,
@@ -26,7 +28,8 @@ fun AbstractMessageModifyBuilder.createPaginatedEmbedMessage(
     nextButtonCustomId: String
 ) {
     createEmbed(
-        locale = locale,
+        guildId = guildId,
+        discordLocale = discordLocale,
         localizationService = localizationService,
         embedTitle = title,
         embedDescription = description,
@@ -37,7 +40,8 @@ fun AbstractMessageModifyBuilder.createPaginatedEmbedMessage(
     )
     if (pageCount > 1) {
         components = getMessageComponentBuilders(
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             localizationService = localizationService,
             previousButtonCustomId = previousButtonCustomId,
             nextButtonCustomId = nextButtonCustomId,
@@ -47,8 +51,9 @@ fun AbstractMessageModifyBuilder.createPaginatedEmbedMessage(
     }
 }
 
-private fun AbstractMessageModifyBuilder.createEmbed(
-    locale: Locale,
+private suspend fun AbstractMessageModifyBuilder.createEmbed(
+    guildId: Snowflake?,
+    discordLocale: Locale?,
     localizationService: LocalizationService,
     embedTitle: String,
     embedDescription: String?,
@@ -77,7 +82,8 @@ private fun AbstractMessageModifyBuilder.createEmbed(
             footer {
                 text = localizationService.getStringFormat(
                     key = LocalizationKeys.PAGINATED_EMBED_FOOTER,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(currentPage, pageCount)
                 )
             }
@@ -85,8 +91,9 @@ private fun AbstractMessageModifyBuilder.createEmbed(
     }
 }
 
-private fun getMessageComponentBuilders(
-    locale: Locale,
+private suspend fun getMessageComponentBuilders(
+    guildId: Snowflake?,
+    discordLocale: Locale?,
     localizationService: LocalizationService,
     previousButtonCustomId: String,
     nextButtonCustomId: String,
@@ -98,7 +105,7 @@ private fun getMessageComponentBuilders(
             style = ButtonStyle.Secondary,
             customId = previousButtonCustomId
         ) {
-            label = localizationService.getString(LocalizationKeys.PAGINATED_EMBED_PREVIOUS_BUTTON_LABEL, locale)
+            label = localizationService.getString(LocalizationKeys.PAGINATED_EMBED_PREVIOUS_BUTTON_LABEL, guildId, discordLocale)
             emoji = DiscordPartialEmoji(name = "⬅")
             disabled = disablePrevious
         }
@@ -106,7 +113,7 @@ private fun getMessageComponentBuilders(
             style = ButtonStyle.Secondary,
             customId = nextButtonCustomId
         ) {
-            label = localizationService.getString(LocalizationKeys.PAGINATED_EMBED_NEXT_BUTTON_LABEL, locale)
+            label = localizationService.getString(LocalizationKeys.PAGINATED_EMBED_NEXT_BUTTON_LABEL, guildId, discordLocale)
             emoji = DiscordPartialEmoji(name = "➡")
             disabled = disableNext
         }

--- a/src/main/kotlin/commands/disconnect/DisconnectCommand.kt
+++ b/src/main/kotlin/commands/disconnect/DisconnectCommand.kt
@@ -9,7 +9,6 @@ import es.wokis.commands.CommandName
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
-import es.wokis.utils.orDefaultLocale
 
 class DisconnectCommand(
     private val guildQueueService: GuildQueueService,
@@ -20,7 +19,7 @@ class DisconnectCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Disconnect.commandName,
-                description = localizationService.getString(key = LocalizationKeys.DISCONNECT_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.DISCONNECT_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.DISCONNECT_COMMAND_DESCRIPTION)
             }
@@ -31,13 +30,15 @@ class DisconnectCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
         guildLavaPlayerService.stop()
         response.respond {
             content = localizationService.getString(
                 key = LocalizationKeys.DISCONNECT_COMMAND_RESPONSE,
-                locale = locale
+                guildId = guildId,
+                discordLocale = discordLocale
             )
         }
     }

--- a/src/main/kotlin/commands/locale/LocaleCommand.kt
+++ b/src/main/kotlin/commands/locale/LocaleCommand.kt
@@ -17,6 +17,7 @@ import es.wokis.commands.CommandName
 import es.wokis.data.locale.DISCORD_LOCALE_MAP
 import es.wokis.data.locale.RESET_LOCALE_VALUE
 import es.wokis.domain.locale.SetGuildLocaleUseCase
+import es.wokis.exceptions.BotException
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 
@@ -55,28 +56,13 @@ class LocaleCommand(
         val discordLocale = interaction.guildLocale
 
         if (guildId == null) {
-            response.respond {
-                content = localizationService.getString(
-                    key = LocalizationKeys.ERROR_NO_GUILD,
-                    guildId = null,
-                    discordLocale = discordLocale
-                )
-            }
-            return
+            throw BotException.UserException.NotInGuildException()
         }
 
         val localeInput = interaction.command.strings[ARGUMENT_LOCALE]
 
         if (localeInput.isNullOrEmpty()) {
-            response.respond {
-                content = localizationService.getStringFormat(
-                    key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
-                    guildId = guildId,
-                    discordLocale = discordLocale,
-                    arguments = arrayOf(ARGUMENT_LOCALE)
-                )
-            }
-            return
+            throw BotException.UserException.NoContentProvidedException()
         }
 
         if (localeInput.equals(RESET_LOCALE_VALUE, ignoreCase = true)) {

--- a/src/main/kotlin/commands/locale/LocaleCommand.kt
+++ b/src/main/kotlin/commands/locale/LocaleCommand.kt
@@ -1,0 +1,139 @@
+package es.wokis.commands.locale
+
+import dev.kord.common.entity.Choice
+import dev.kord.common.entity.Permission
+import dev.kord.common.entity.Permissions
+import dev.kord.common.entity.optional.Optional
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.behavior.interaction.suggest
+import dev.kord.core.entity.interaction.AutoCompleteInteraction
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
+import dev.kord.rest.builder.interaction.string
+import es.wokis.commands.Autocomplete
+import es.wokis.commands.Command
+import es.wokis.commands.CommandName
+import es.wokis.data.locale.DISCORD_LOCALE_MAP
+import es.wokis.data.locale.RESET_LOCALE_VALUE
+import es.wokis.domain.locale.SetGuildLocaleUseCase
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.localization.LocalizationService
+
+private const val ARGUMENT_LOCALE = "locale"
+
+class LocaleCommand(
+    private val localizationService: LocalizationService,
+    private val setGuildLocaleUseCase: SetGuildLocaleUseCase
+) : Command, Autocomplete {
+
+    override fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
+        commandBuilder.apply {
+            input(
+                name = CommandName.Locale.commandName,
+                description = localizationService.getLocalizations(LocalizationKeys.LOCALE_COMMAND_DESCRIPTION).values.first()
+            ) {
+                descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.LOCALE_COMMAND_DESCRIPTION)
+                defaultMemberPermissions = Permissions(Permission.Administrator)
+                string(
+                    name = ARGUMENT_LOCALE,
+                    description = localizationService.getLocalizations(LocalizationKeys.LOCALE_COMMAND_INPUT_DESCRIPTION).values.first()
+                ) {
+                    descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.LOCALE_COMMAND_INPUT_DESCRIPTION)
+                    required = true
+                    autocomplete = true
+                }
+            }
+        }
+    }
+
+    override suspend fun onExecute(
+        interaction: ChatInputCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior
+    ) {
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
+
+        if (guildId == null) {
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ERROR_NO_GUILD,
+                    guildId = null,
+                    discordLocale = discordLocale
+                )
+            }
+            return
+        }
+
+        val localeInput = interaction.command.strings[ARGUMENT_LOCALE]
+
+        if (localeInput.isNullOrEmpty()) {
+            response.respond {
+                content = localizationService.getStringFormat(
+                    key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
+                    arguments = arrayOf(ARGUMENT_LOCALE)
+                )
+            }
+            return
+        }
+
+        if (localeInput.equals(RESET_LOCALE_VALUE, ignoreCase = true)) {
+            setGuildLocaleUseCase.removeLocale(guildId)
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.LOCALE_COMMAND_RESET_SUCCESS,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+            return
+        }
+
+        val selectedLocale = DISCORD_LOCALE_MAP[localeInput]
+
+        if (selectedLocale == null) {
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.LOCALE_COMMAND_INVALID_LOCALE,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+            return
+        }
+
+        setGuildLocaleUseCase(guildId, selectedLocale)
+        response.respond {
+            content = localizationService.getStringFormat(
+                key = LocalizationKeys.LOCALE_COMMAND_SUCCESS,
+                guildId = guildId,
+                discordLocale = discordLocale,
+                arguments = arrayOf(localeInput)
+            )
+        }
+    }
+
+    override suspend fun onAutoComplete(interaction: AutoCompleteInteraction) {
+        val input = interaction.command.strings[ARGUMENT_LOCALE].orEmpty().lowercase()
+
+        val suggestions = if (input.isEmpty()) {
+            DISCORD_LOCALE_MAP.entries
+        } else {
+            DISCORD_LOCALE_MAP.entries.filter { (code, _) ->
+                code.lowercase().contains(input)
+            }
+        }
+            .take(25)
+            .map { (code, _) ->
+                Choice.StringChoice(
+                    name = code.take(100),
+                    nameLocalizations = Optional.Missing(),
+                    value = code
+                )
+            }
+
+        interaction.suggest(suggestions)
+    }
+}

--- a/src/main/kotlin/commands/next/NextCommand.kt
+++ b/src/main/kotlin/commands/next/NextCommand.kt
@@ -12,7 +12,6 @@ import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.utils.getDisplayTrackName
 import es.wokis.utils.isValidUrl
-import es.wokis.utils.orDefaultLocale
 import es.wokis.utils.takeIfNotEmpty
 import es.wokis.utils.transformUrl
 
@@ -27,12 +26,12 @@ class NextCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Next.commandName,
-                description = localizationService.getString(LocalizationKeys.NEXT_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.NEXT_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.NEXT_COMMAND_DESCRIPTION)
                 string(
                     name = ARGUMENT_NAME,
-                    description = localizationService.getString(LocalizationKeys.NEXT_COMMAND_INPUT_DESCRIPTION)
+                    description = localizationService.getLocalizations(LocalizationKeys.NEXT_COMMAND_INPUT_DESCRIPTION).values.first()
                 ) {
                     descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.NEXT_COMMAND_INPUT_DESCRIPTION)
                     required = true
@@ -45,12 +44,14 @@ class NextCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val input: String = interaction.command.strings[ARGUMENT_NAME]?.takeIfNotEmpty()
             ?: response.respond {
                 content = localizationService.getStringFormat(
                     key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(ARGUMENT_NAME)
                 )
             }.let { return }
@@ -61,7 +62,7 @@ class NextCommand(
             // URL case: transform monochrome URLs and load as next
             val transformedUrl = input.transformUrl()
             response.respond {
-                content = localizationService.getString(LocalizationKeys.SEARCHING_SONG, locale)
+                content = localizationService.getString(LocalizationKeys.SEARCHING_SONG, guildId, discordLocale)
             }
             guildLavaPlayerService.loadAndPlay(transformedUrl, addToFront = true)
         } else {
@@ -70,7 +71,8 @@ class NextCommand(
                 response.respond {
                     content = localizationService.getString(
                         LocalizationKeys.NEXT_EMPTY_QUEUE,
-                        locale
+                        guildId,
+                        discordLocale
                     )
                 }
                 return
@@ -82,7 +84,8 @@ class NextCommand(
                 response.respond {
                     content = localizationService.getStringFormat(
                         key = LocalizationKeys.NEXT_TRACK_MOVED,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(movedTrack.getDisplayTrackName())
                     )
                 }
@@ -92,7 +95,8 @@ class NextCommand(
                 response.respond {
                     content = localizationService.getStringFormat(
                         key = LocalizationKeys.NEXT_TRACK_NOT_IN_QUEUE_TRYING_SEARCH,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(input)
                     )
                 }

--- a/src/main/kotlin/commands/play/PlayCommand.kt
+++ b/src/main/kotlin/commands/play/PlayCommand.kt
@@ -10,7 +10,6 @@ import es.wokis.commands.CommandName
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
-import es.wokis.utils.orDefaultLocale
 import es.wokis.utils.takeIfNotEmpty
 import es.wokis.utils.transformUrl
 
@@ -26,12 +25,12 @@ class PlayCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Play.commandName,
-                description = localizationService.getString(LocalizationKeys.PLAY_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.PLAY_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.PLAY_COMMAND_DESCRIPTION)
                 string(
                     name = ARGUMENT_NAME,
-                    description = localizationService.getString(LocalizationKeys.PLAY_COMMAND_INPUT_DESCRIPTION)
+                    description = localizationService.getLocalizations(LocalizationKeys.PLAY_COMMAND_INPUT_DESCRIPTION).values.first()
                 ) {
                     descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.PLAY_COMMAND_INPUT_DESCRIPTION)
                     required = true
@@ -44,17 +43,23 @@ class PlayCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val input: String = interaction.command.strings[ARGUMENT_NAME]?.takeIfNotEmpty()
             ?: response.respond {
                 content = localizationService.getStringFormat(
                     key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(ARGUMENT_NAME)
                 )
             }.let { return }
         response.respond {
-            content = localizationService.getString(LocalizationKeys.SEARCHING_SONG, locale)
+            content = localizationService.getString(
+                LocalizationKeys.SEARCHING_SONG,
+                guildId = guildId,
+                discordLocale = discordLocale
+            )
         }
 
         val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)

--- a/src/main/kotlin/commands/player/PlayerCommand.kt
+++ b/src/main/kotlin/commands/player/PlayerCommand.kt
@@ -7,6 +7,8 @@ import dev.kord.core.entity.interaction.ButtonInteraction
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.core.entity.interaction.ComponentInteraction
 import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
 import es.wokis.commands.Command
 import es.wokis.commands.CommandName
 import es.wokis.commands.Component
@@ -88,8 +90,8 @@ class PlayerCommand(
     }
 
     private suspend fun onPlayerChannelSearchFailed(
-        guildId: dev.kord.common.entity.Snowflake?,
-        discordLocale: dev.kord.common.Locale?,
+        guildId: Snowflake?,
+        discordLocale: Locale?,
         response: DeferredPublicMessageInteractionResponseBehavior,
         guildName: String,
         currentTrack: TrackBO?,
@@ -121,8 +123,8 @@ class PlayerCommand(
         playerMessageResult: Result<PlayerChannelResult>,
         lavaPlayerService: GuildLavaPlayerService,
         response: DeferredPublicMessageInteractionResponseBehavior,
-        guildId: dev.kord.common.entity.Snowflake?,
-        discordLocale: dev.kord.common.Locale?
+        guildId: Snowflake?,
+        discordLocale: Locale?
     ) {
         playerMessageResult.getOrNull()?.let { result ->
             lavaPlayerService.savePlayerMessage(result.message)

--- a/src/main/kotlin/commands/player/PlayerCommand.kt
+++ b/src/main/kotlin/commands/player/PlayerCommand.kt
@@ -1,6 +1,5 @@
 package es.wokis.commands.player
 
-import dev.kord.common.Locale
 import dev.kord.core.behavior.edit
 import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
 import dev.kord.core.behavior.interaction.response.respond
@@ -19,7 +18,6 @@ import es.wokis.services.localization.LocalizationService
 import es.wokis.services.player.PlayerChannelService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.utils.getGuildName
-import es.wokis.utils.orDefaultLocale
 import services.player.result.PlayerChannelResult
 
 class PlayerCommand(
@@ -32,7 +30,7 @@ class PlayerCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Player.commandName,
-                description = localizationService.getString(key = LocalizationKeys.PLAYER_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.PLAYER_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.PLAYER_COMMAND_DESCRIPTION)
             }
@@ -47,14 +45,16 @@ class PlayerCommand(
             val lavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
             val currentTrack = lavaPlayerService.getCurrentPlayingTrack()
             val queue: List<TrackBO> = lavaPlayerService.getQueue()
-            val locale = interaction.guildLocale.orDefaultLocale()
+            val guildId = interaction.data.guildId.value
+            val discordLocale = interaction.guildLocale
             val guildName = interaction.getGuildName()
 
             val playerMessageResult = playerChannelService.sendPlayerMessage(interaction) {
                 createPlayerEmbed(
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     guildName = guildName,
                     localizationService = localizationService,
-                    locale = locale,
                     currentTrack = currentTrack,
                     queue = queue,
                     isPaused = lavaPlayerService.isPaused()
@@ -66,11 +66,13 @@ class PlayerCommand(
                     playerMessageResult = playerMessageResult,
                     lavaPlayerService = lavaPlayerService,
                     response = response,
-                    locale = locale
+                    guildId = guildId,
+                    discordLocale = discordLocale
                 )
             } else {
                 onPlayerChannelSearchFailed(
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     response = response,
                     guildName = guildName,
                     currentTrack = currentTrack,
@@ -86,7 +88,8 @@ class PlayerCommand(
     }
 
     private suspend fun onPlayerChannelSearchFailed(
-        locale: Locale,
+        guildId: dev.kord.common.entity.Snowflake?,
+        discordLocale: dev.kord.common.Locale?,
         response: DeferredPublicMessageInteractionResponseBehavior,
         guildName: String,
         currentTrack: TrackBO?,
@@ -95,14 +98,16 @@ class PlayerCommand(
     ) {
         val warningMessage = localizationService.getString(
             LocalizationKeys.PLAYER_CHANNEL_CREATION_FAILED,
-            locale
+            guildId,
+            discordLocale
         )
         response.respond {
             content = warningMessage
             createPlayerEmbed(
+                guildId = guildId,
+                discordLocale = discordLocale,
                 guildName = guildName,
                 localizationService = localizationService,
-                locale = locale,
                 currentTrack = currentTrack,
                 queue = queue,
                 isPaused = lavaPlayerService.isPaused()
@@ -116,7 +121,8 @@ class PlayerCommand(
         playerMessageResult: Result<PlayerChannelResult>,
         lavaPlayerService: GuildLavaPlayerService,
         response: DeferredPublicMessageInteractionResponseBehavior,
-        locale: Locale
+        guildId: dev.kord.common.entity.Snowflake?,
+        discordLocale: dev.kord.common.Locale?
     ) {
         playerMessageResult.getOrNull()?.let { result ->
             lavaPlayerService.savePlayerMessage(result.message)
@@ -127,7 +133,8 @@ class PlayerCommand(
                     } else {
                         LocalizationKeys.PLAYER_SHOWN_ON_EXISTING_CHANNEL
                     },
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(result.channel.id)
                 )
             }
@@ -149,14 +156,16 @@ class PlayerCommand(
         }
         val currentTrack = lavaPlayerService?.getCurrentPlayingTrack()
         val queue: List<TrackBO> = lavaPlayerService?.getQueue().orEmpty()
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val guildName = interaction.getGuildName()
 
         interaction.message.edit {
             createPlayerEmbed(
+                guildId = guildId,
+                discordLocale = discordLocale,
                 guildName = guildName,
                 localizationService = localizationService,
-                locale = locale,
                 currentTrack = currentTrack,
                 queue = queue,
                 isPaused = lavaPlayerService?.isPaused() == true

--- a/src/main/kotlin/commands/player/PlayerCommons.kt
+++ b/src/main/kotlin/commands/player/PlayerCommons.kt
@@ -5,12 +5,11 @@ import dev.kord.common.Color
 import dev.kord.common.Locale
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.DiscordPartialEmoji
+import dev.kord.common.entity.Snowflake
 import dev.kord.rest.builder.component.ActionRowBuilder
 import dev.kord.rest.builder.component.MessageComponentBuilder
 import dev.kord.rest.builder.message.MessageBuilder
 import dev.kord.rest.builder.message.embed
-import dev.kord.rest.builder.message.create.MessageCreateBuilder
-import dev.kord.rest.builder.message.modify.AbstractMessageModifyBuilder
 import es.wokis.commands.ComponentsEnum
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.lavaplayer.model.TrackBO
@@ -21,10 +20,11 @@ import kotlin.time.toDuration
 
 private const val ENABLE_PLAYBACK_POSITION = false
 
-fun MessageBuilder.createPlayerEmbed(
+suspend fun MessageBuilder.createPlayerEmbed(
+    guildId: Snowflake?,
+    discordLocale: Locale?,
     guildName: String,
     localizationService: LocalizationService,
-    locale: Locale,
     currentTrack: TrackBO?,
     queue: List<TrackBO>,
     isPaused: Boolean
@@ -32,7 +32,8 @@ fun MessageBuilder.createPlayerEmbed(
     embed {
         title = localizationService.getStringFormat(
             key = LocalizationKeys.PLAYER_TITLE,
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             arguments = arrayOf(guildName)
         )
         thumbnail {
@@ -43,39 +44,41 @@ fun MessageBuilder.createPlayerEmbed(
             val duration = it.audioTrack.duration.toDisplayDuration()
             val currentSeek = it.audioTrack.position.toDisplayDuration()
             field {
-                name = localizationService.getString(key = LocalizationKeys.PLAYER_CURRENT_TRACK, locale = locale)
+                name = localizationService.getString(key = LocalizationKeys.PLAYER_CURRENT_TRACK, guildId = guildId, discordLocale = discordLocale)
                 value = it.getTrackName()
             }
             if (ENABLE_PLAYBACK_POSITION) {
                 // TODO: Take a look in the future to solve discord update request error or delete it
                 field {
-                    name = localizationService.getString(key = LocalizationKeys.PLAYER_PLAYBACK_POSITION, locale = locale)
+                    name = localizationService.getString(key = LocalizationKeys.PLAYER_PLAYBACK_POSITION, guildId = guildId, discordLocale = discordLocale)
                     value = "`$currentSeek ${generatePlayerPosition(it.audioTrack.position, it.audioTrack.duration)} $duration`"
                 }
             }
             field {
-                name = localizationService.getString(key = LocalizationKeys.PLAYER_TRACK_DURATION, locale = locale)
+                name = localizationService.getString(key = LocalizationKeys.PLAYER_TRACK_DURATION, guildId = guildId, discordLocale = discordLocale)
                 value = duration.takeUnless {
                     currentTrack.audioTrack.duration == DURATION_MS_UNKNOWN
                 } ?: localizationService.getString(
                     key = if (currentTrack.audioTrack.info.isStream) LocalizationKeys.PLAYER_TRACK_DURATION_STREAM else LocalizationKeys.PLAYER_TRACK_DURATION_UNKNOWN,
-                    locale = locale
+                    guildId = guildId,
+                    discordLocale = discordLocale
                 )
             }
         }
         if (queue.isNotEmpty()) {
             field {
-                name = localizationService.getString(key = LocalizationKeys.PLAYER_SERVER_QUEUE, locale = locale)
-                value = queue.getDisplayQueue(localizationService, locale)
+                name = localizationService.getString(key = LocalizationKeys.PLAYER_SERVER_QUEUE, guildId = guildId, discordLocale = discordLocale)
+                value = queue.getDisplayQueue(localizationService, guildId, discordLocale)
             }
         } else if (currentTrack == null) {
-            description = localizationService.getString(key = LocalizationKeys.PLAYER_SERVER_QUEUE_EMPTY, locale = locale)
+            description = localizationService.getString(key = LocalizationKeys.PLAYER_SERVER_QUEUE_EMPTY, guildId = guildId, discordLocale = discordLocale)
         }
     }
     components = if (queue.isNotEmpty() || currentTrack != null) {
         createPlayerComponents(
             localizationService = localizationService,
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             isPaused = isPaused
         )
     } else {
@@ -96,7 +99,7 @@ private fun generatePlayerPosition(currentSeek: Long, maxDuration: Long): String
     return playerString
 }
 
-private fun createPlayerComponents(localizationService: LocalizationService, locale: Locale, isPaused: Boolean): MutableList<MessageComponentBuilder> =
+private suspend fun createPlayerComponents(localizationService: LocalizationService, guildId: Snowflake?, discordLocale: Locale?, isPaused: Boolean): MutableList<MessageComponentBuilder> =
     mutableListOf(
         ActionRowBuilder().apply {
             if (isPaused) {
@@ -104,7 +107,7 @@ private fun createPlayerComponents(localizationService: LocalizationService, loc
                     style = ButtonStyle.Secondary,
                     customId = ComponentsEnum.PLAYER_RESUME.customId
                 ) {
-                    label = localizationService.getString(key = LocalizationKeys.PLAYER_RESUME, locale = locale)
+                    label = localizationService.getString(key = LocalizationKeys.PLAYER_RESUME, guildId = guildId, discordLocale = discordLocale)
                     emoji = DiscordPartialEmoji(name = "▶️")
                 }
             } else {
@@ -112,7 +115,7 @@ private fun createPlayerComponents(localizationService: LocalizationService, loc
                     style = ButtonStyle.Secondary,
                     customId = ComponentsEnum.PLAYER_PAUSE.customId
                 ) {
-                    label = localizationService.getString(key = LocalizationKeys.PLAYER_PAUSE, locale = locale)
+                    label = localizationService.getString(key = LocalizationKeys.PLAYER_PAUSE, guildId = guildId, discordLocale = discordLocale)
                     emoji = DiscordPartialEmoji(name = "⏸")
                 }
             }
@@ -120,47 +123,48 @@ private fun createPlayerComponents(localizationService: LocalizationService, loc
                 style = ButtonStyle.Secondary,
                 customId = ComponentsEnum.PLAYER_SKIP.customId
             ) {
-                label = localizationService.getString(key = LocalizationKeys.PLAYER_SKIP, locale = locale)
+                label = localizationService.getString(key = LocalizationKeys.PLAYER_SKIP, guildId = guildId, discordLocale = discordLocale)
                 emoji = DiscordPartialEmoji(name = "⏭")
             }
             interactionButton(
                 style = ButtonStyle.Secondary,
                 customId = ComponentsEnum.PLAYER_SHUFFLE.customId
             ) {
-                label = localizationService.getString(key = LocalizationKeys.PLAYER_SHUFFLE, locale = locale)
+                label = localizationService.getString(key = LocalizationKeys.PLAYER_SHUFFLE, guildId = guildId, discordLocale = discordLocale)
                 emoji = DiscordPartialEmoji(name = "\uD83D\uDD00")
             }
             interactionButton(
                 style = ButtonStyle.Secondary,
                 customId = ComponentsEnum.PLAYER_RECONNECT.customId
             ) {
-                label = localizationService.getString(key = LocalizationKeys.PLAYER_RECONNECT, locale = locale)
+                label = localizationService.getString(key = LocalizationKeys.PLAYER_RECONNECT, guildId = guildId, discordLocale = discordLocale)
                 emoji = DiscordPartialEmoji(name = "🔄")
             }
             interactionButton(
                 style = ButtonStyle.Danger,
                 customId = ComponentsEnum.PLAYER_DISCONNECT.customId
             ) {
-                label = localizationService.getString(key = LocalizationKeys.PLAYER_DISCONNECT, locale = locale)
+                label = localizationService.getString(key = LocalizationKeys.PLAYER_DISCONNECT, guildId = guildId, discordLocale = discordLocale)
             }
         }
     )
 
-private fun List<TrackBO>.getDisplayQueue(localizationService: LocalizationService, locale: Locale): String {
+private suspend fun List<TrackBO>.getDisplayQueue(localizationService: LocalizationService, guildId: Snowflake?, discordLocale: Locale?): String {
     val firstTrack = getOrNull(0)
     val secondTrack = getOrNull(1)
     val thirdTrack = getOrNull(2)
     val queueRemaining = (size - 3).takeIf { it > 0 }
     val duration = filterNot { it.audioTrack.info.isStream || it.audioTrack.duration == DURATION_MS_UNKNOWN }.sumOf { it.audioTrack.duration }.toDisplayDuration()
-    return firstTrack?.getDisplayNameAndDuration(localizationService, locale)
-        ?.plus(secondTrack?.let { "\n${it.getDisplayNameAndDuration(localizationService, locale)}" }.orEmpty())
-        ?.plus(thirdTrack?.let { "\n${it.getDisplayNameAndDuration(localizationService, locale)}" }.orEmpty())
+    return firstTrack?.getDisplayNameAndDuration(localizationService, guildId, discordLocale)
+        ?.plus(secondTrack?.let { "\n${it.getDisplayNameAndDuration(localizationService, guildId, discordLocale)}" }.orEmpty())
+        ?.plus(thirdTrack?.let { "\n${it.getDisplayNameAndDuration(localizationService, guildId, discordLocale)}" }.orEmpty())
         ?.plus(
             queueRemaining?.let {
                 "\n".plus(
                     localizationService.getStringFormat(
                         key = LocalizationKeys.PLAYER_QUEUE_TRACKS_REMAINING,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(it)
                     )
                 )
@@ -170,18 +174,19 @@ private fun List<TrackBO>.getDisplayQueue(localizationService: LocalizationServi
             "\n".plus(
                 localizationService.getStringFormat(
                     key = LocalizationKeys.PLAYER_DURATION_REMAINING,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(duration)
                 )
             )
         ).orEmpty()
 }
 
-private fun TrackBO.getDisplayNameAndDuration(localizationService: LocalizationService, locale: Locale): String {
+private suspend fun TrackBO.getDisplayNameAndDuration(localizationService: LocalizationService, guildId: Snowflake?, discordLocale: Locale?): String {
     val displayDuration = if (audioTrack.duration != DURATION_MS_UNKNOWN) {
         audioTrack.duration.toDisplayDuration()
     } else {
-        localizationService.getString(LocalizationKeys.PLAYER_TRACK_DURATION_STREAM, locale)
+        localizationService.getString(LocalizationKeys.PLAYER_TRACK_DURATION_STREAM, guildId, discordLocale)
     }
     return "${getDisplayTrackName()} ($displayDuration)"
 }

--- a/src/main/kotlin/commands/queue/QueueCommand.kt
+++ b/src/main/kotlin/commands/queue/QueueCommand.kt
@@ -19,7 +19,6 @@ import es.wokis.services.lavaplayer.model.TrackBO
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.utils.getDisplayTrackName
-import es.wokis.utils.orDefaultLocale
 
 class QueueCommand(
     private val guildQueueService: GuildQueueService,
@@ -29,7 +28,7 @@ class QueueCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Queue.commandName,
-                description = localizationService.getString(LocalizationKeys.QUEUE_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.QUEUE_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.QUEUE_COMMAND_DESCRIPTION)
             }
@@ -41,24 +40,27 @@ class QueueCommand(
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
         try {
-            val locale = interaction.guildLocale.orDefaultLocale()
+            val guildId = interaction.data.guildId.value
+            val discordLocale = interaction.guildLocale
             val guildQueue = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
             // This should never be null, if so it would throw an expected exception on getOrCreateLavaPlayerService
-            val guildId = interaction.data.guildId.value ?: return
-            val guildName = interaction.kord.getGuild(guildId).name
+            val resolvedGuildId = guildId ?: return
+            val guildName = interaction.kord.getGuild(resolvedGuildId).name
             val queue = guildQueue.getQueue().toList()
             val displayQueue = getDisplayQueue(queue)
             val description = localizationService.getStringFormat(
                 key = LocalizationKeys.QUEUE_EMBED_DESCRIPTION,
-                locale = locale,
+                guildId = guildId,
+                discordLocale = discordLocale,
                 arguments = arrayOf(queue.size, guildName)
             )
             val currentPageContent = displayQueue.takeIf { it.isNotEmpty() }?.get(0)?.let { listOf(it) }
             response.respond {
                 createPaginatedEmbedMessage(
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     localizationService = localizationService,
-                    title = localizationService.getString(LocalizationKeys.QUEUE_EMBED_TITLE, locale),
+                    title = localizationService.getString(LocalizationKeys.QUEUE_EMBED_TITLE, guildId, discordLocale),
                     description = description,
                     currentPage = 1,
                     currentPageContent = currentPageContent,
@@ -77,6 +79,7 @@ class QueueCommand(
 
     override suspend fun onInteract(interaction: ComponentInteraction) {
         val guildId = interaction.data.guildId.value ?: return
+        val discordLocale = interaction.guildLocale
         val interactionCustomId = (interaction as? ButtonInteraction)?.component?.customId
         val updatePageBy = if (interactionCustomId == ComponentsEnum.QUEUE_PREVIOUS.customId) -1 else 1
         val guildName = interaction.kord.getGuild(guildId).name
@@ -87,6 +90,8 @@ class QueueCommand(
             ?.takeUnless { it > displayQueue.size } ?: 1
         updateQueueMessage(
             interaction = interaction,
+            guildId = guildId,
+            discordLocale = discordLocale,
             currentPage = currentPage,
             queueLength = guildQueue.size,
             guildName = guildName,
@@ -118,24 +123,27 @@ class QueueCommand(
 
     private suspend fun updateQueueMessage(
         interaction: ComponentInteraction,
+        guildId: dev.kord.common.entity.Snowflake,
+        discordLocale: dev.kord.common.Locale?,
         currentPage: Int,
         queueLength: Int,
         guildName: String,
         displayQueuePage: String?,
         queuePageLength: Int
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
         val description = localizationService.getStringFormat(
             key = LocalizationKeys.QUEUE_EMBED_DESCRIPTION,
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             arguments = arrayOf(queueLength, guildName)
         )
         val currentPageContent = displayQueuePage?.let { listOf(it) }
         interaction.message.edit {
             createPaginatedEmbedMessage(
-                locale = locale,
+                guildId = guildId,
+                discordLocale = discordLocale,
                 localizationService = localizationService,
-                title = localizationService.getString(LocalizationKeys.QUEUE_EMBED_TITLE, locale),
+                title = localizationService.getString(LocalizationKeys.QUEUE_EMBED_TITLE, guildId, discordLocale),
                 description = description,
                 currentPage = currentPage,
                 columns = 1,

--- a/src/main/kotlin/commands/queue/QueueCommand.kt
+++ b/src/main/kotlin/commands/queue/QueueCommand.kt
@@ -9,6 +9,8 @@ import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.core.entity.interaction.ComponentInteraction
 import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
 import dev.kord.rest.builder.message.EmbedBuilder
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
 import es.wokis.commands.Command
 import es.wokis.commands.CommandName
 import es.wokis.commands.Component
@@ -123,8 +125,8 @@ class QueueCommand(
 
     private suspend fun updateQueueMessage(
         interaction: ComponentInteraction,
-        guildId: dev.kord.common.entity.Snowflake,
-        discordLocale: dev.kord.common.Locale?,
+        guildId: Snowflake,
+        discordLocale: Locale?,
         currentPage: Int,
         queueLength: Int,
         guildName: String,

--- a/src/main/kotlin/commands/radio/RadioGroupCommand.kt
+++ b/src/main/kotlin/commands/radio/RadioGroupCommand.kt
@@ -33,7 +33,7 @@ class RadioGroupCommand(
 ) : GroupCommand, Component, Autocomplete {
 
     override suspend fun onRegisterCommand(kord: Kord) {
-        kord.createGlobalChatInputCommand(CommandName.Radio.commandName, localizationService.getString(LocalizationKeys.RADIO_COMMAND_DESCRIPTION)) {
+        kord.createGlobalChatInputCommand(CommandName.Radio.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_COMMAND_DESCRIPTION).values.first()) {
             descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_COMMAND_DESCRIPTION)
             radioPlayCommand.onRegisterCommand(this)
             radioListCommand.onRegisterCommand(this)
@@ -47,6 +47,8 @@ class RadioGroupCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val commandName = (interaction.command as? KordSubCommand)?.name ?: (interaction.command as? KordGroupCommand)?.groupName
         commandName?.let {
             when (commandName) {
@@ -57,7 +59,7 @@ class RadioGroupCommand(
                 CommandName.Radio.Random.commandName -> radioRandomCommand.onExecute(interaction, response)
             }
         } ?: response.respond {
-            content = localizationService.getString(LocalizationKeys.RADIO_UNKNOWN_MESSAGE)
+            content = localizationService.getString(LocalizationKeys.RADIO_UNKNOWN_MESSAGE, guildId, discordLocale)
         }
     }
 

--- a/src/main/kotlin/commands/radio/RadioUtils.kt
+++ b/src/main/kotlin/commands/radio/RadioUtils.kt
@@ -1,5 +1,7 @@
 package es.wokis.commands.radio
 
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.edit
 import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
 import dev.kord.core.behavior.interaction.response.respond
@@ -12,7 +14,6 @@ import es.wokis.data.radio.RadioDTO
 import es.wokis.data.radio.RadioPageDTO
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
-import es.wokis.utils.orDefaultLocale
 import es.wokis.utils.takeAtMost
 
 private const val RADIO_LIST_COLUMNS = 3
@@ -31,15 +32,17 @@ suspend fun onExecuteRadioListCommand(
     nextButtonCustomId: String,
     localizationService: LocalizationService
 ) {
-    val locale = interaction.locale.orDefaultLocale()
+    val guildId = interaction.data.guildId.value
+    val discordLocale = interaction.guildLocale
     val radioPageContent = currentRadioPage?.radios?.chunked(RADIO_LIST_COLUMNS)
     val maxPages = currentRadioPage?.maxPage ?: 1
     response.respond {
         createPaginatedEmbedMessage(
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             localizationService = localizationService,
-            title = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_TITLE, locale),
-            description = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_DESCRIPTION, locale),
+            title = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_TITLE, guildId, discordLocale),
+            description = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_DESCRIPTION, guildId, discordLocale),
             currentPage = 1,
             currentPageContent = radioPageContent,
             columns = RADIO_LIST_COLUMNS,
@@ -57,7 +60,8 @@ suspend fun onInteractRadioListCommand(
     nextButtonCustomId: String,
     block: suspend (Int) -> RadioPageDTO?
 ) {
-    val locale = interaction.locale.orDefaultLocale()
+    val guildId = interaction.data.guildId.value
+    val discordLocale = interaction.guildLocale
     val customId = (interaction as? ButtonInteraction)?.component?.customId
     val updatePageBy = if (customId == nextButtonCustomId) 1 else -1
     val footerSplit = interaction.message.embeds.firstOrNull()
@@ -69,10 +73,11 @@ suspend fun onInteractRadioListCommand(
     val radioPageContent = newRadioPage?.radios?.chunked(RADIO_LIST_COLUMNS)
     interaction.message.edit {
         createPaginatedEmbedMessage(
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             localizationService = localizationService,
-            title = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_TITLE, locale),
-            description = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_DESCRIPTION, locale),
+            title = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_TITLE, guildId, discordLocale),
+            description = localizationService.getString(LocalizationKeys.RADIO_LIST_EMBED_DESCRIPTION, guildId, discordLocale),
             currentPage = currentPage,
             currentPageContent = radioPageContent,
             columns = RADIO_LIST_COLUMNS,

--- a/src/main/kotlin/commands/radio/subcommands/countrycodes/RadioCountryCodesCommand.kt
+++ b/src/main/kotlin/commands/radio/subcommands/countrycodes/RadioCountryCodesCommand.kt
@@ -15,7 +15,6 @@ import es.wokis.data.response.RemoteResponse
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.radio.RadioService
-import es.wokis.utils.orDefaultLocale
 
 private const val MAX_FIELD_LENGTH = 1000 // Stay under 1024 limit
 private const val MAX_FIELDS = 25 // Discord embed limit
@@ -76,7 +75,7 @@ class RadioCountryCodesCommand(
 
     override suspend fun onRegisterCommand(builder: GlobalChatInputCreateBuilder) {
         builder.apply {
-            subCommand(CommandName.Radio.CountryCodes.commandName, localizationService.getString(LocalizationKeys.RADIO_COUNTRYCODES_COMMAND_DESCRIPTION)) {
+            subCommand(CommandName.Radio.CountryCodes.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_COUNTRYCODES_COMMAND_DESCRIPTION).values.first()) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_COUNTRYCODES_COMMAND_DESCRIPTION)
             }
         }
@@ -86,7 +85,8 @@ class RadioCountryCodesCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
 
         when (val result = radioService.getCountryCodes()) {
             is RemoteResponse.Success -> {
@@ -96,7 +96,8 @@ class RadioCountryCodesCommand(
                     response.respond {
                         content = localizationService.getString(
                             key = LocalizationKeys.RADIO_COUNTRYCODES_EMPTY,
-                            locale = locale
+                            guildId = guildId,
+                            discordLocale = discordLocale
                         )
                     }
                     return
@@ -108,7 +109,8 @@ class RadioCountryCodesCommand(
                     embed {
                         title = localizationService.getString(
                             key = LocalizationKeys.RADIO_COUNTRYCODES_EMBED_TITLE,
-                            locale = locale
+                            guildId = guildId,
+                            discordLocale = discordLocale
                         )
                         color = Color(0x01B05B)
 
@@ -127,7 +129,8 @@ class RadioCountryCodesCommand(
                 response.respond {
                     content = localizationService.getString(
                         key = LocalizationKeys.RADIO_COUNTRYCODES_ERROR,
-                        locale = locale
+                        guildId = guildId,
+                        discordLocale = discordLocale
                     )
                 }
             }

--- a/src/main/kotlin/commands/radio/subcommands/list/RadioListCommand.kt
+++ b/src/main/kotlin/commands/radio/subcommands/list/RadioListCommand.kt
@@ -22,7 +22,7 @@ class RadioListCommand(
 
     override suspend fun onRegisterCommand(builder: GlobalChatInputCreateBuilder) {
         builder.apply {
-            subCommand(CommandName.Radio.List.commandName, localizationService.getString(LocalizationKeys.RADIO_LIST_COMMAND_DESCRIPTION)) {
+            subCommand(CommandName.Radio.List.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_LIST_COMMAND_DESCRIPTION).values.first()) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_LIST_COMMAND_DESCRIPTION)
             }
         }

--- a/src/main/kotlin/commands/radio/subcommands/play/RadioPlayCommand.kt
+++ b/src/main/kotlin/commands/radio/subcommands/play/RadioPlayCommand.kt
@@ -19,7 +19,6 @@ import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.services.radio.RadioService
-import es.wokis.utils.orDefaultLocale
 import es.wokis.utils.takeAtMost
 import es.wokis.utils.takeIfNotEmpty
 
@@ -33,9 +32,9 @@ class RadioPlayCommand(
 
     override suspend fun onRegisterCommand(builder: GlobalChatInputCreateBuilder) {
         builder.apply {
-            subCommand(CommandName.Radio.Play.commandName, localizationService.getString(LocalizationKeys.RADIO_PLAY_COMMAND_DESCRIPTION)) {
+            subCommand(CommandName.Radio.Play.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_PLAY_COMMAND_DESCRIPTION).values.first()) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_PLAY_COMMAND_DESCRIPTION)
-                string(RADIO_INPUT_NAME, localizationService.getString(LocalizationKeys.RADIO_PLAY_INPUT_DESCRIPTION)) {
+                string(RADIO_INPUT_NAME, localizationService.getLocalizations(LocalizationKeys.RADIO_PLAY_INPUT_DESCRIPTION).values.first()) {
                     descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_PLAY_INPUT_DESCRIPTION)
                     required = true
                     autocomplete = true
@@ -48,22 +47,23 @@ class RadioPlayCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val radioName = interaction.command.strings[RADIO_INPUT_NAME]
         val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
         radioName?.let {
-            val locale = interaction.guildLocale.orDefaultLocale()
             val originalResponse = response.respond {
                 content = localizationService.getStringFormat(
                     key = LocalizationKeys.SEARCHING_SONG,
-                    locale = locale
+                    guildId = guildId,
+                    discordLocale = discordLocale
                 )
             }
             radioService.findRadio(radioName).let { radio ->
-                val responseLocale = interaction.guildLocale.orDefaultLocale()
                 originalResponse.edit {
                     content = radio?.let {
-                        localizationService.getString(LocalizationKeys.RADIO_PLAY_FOUND, responseLocale)
-                    } ?: localizationService.getString(LocalizationKeys.RADIO_PLAY_NOT_FOUND, responseLocale)
+                        localizationService.getString(LocalizationKeys.RADIO_PLAY_FOUND, guildId, discordLocale)
+                    } ?: localizationService.getString(LocalizationKeys.RADIO_PLAY_NOT_FOUND, guildId, discordLocale)
                 }
                 radio?.let {
                     guildLavaPlayerService.playRadio(
@@ -74,8 +74,7 @@ class RadioPlayCommand(
                 }
             }
         } ?: response.respond {
-            val errorLocale = interaction.guildLocale.orDefaultLocale()
-            content = localizationService.getString(LocalizationKeys.RADIO_PLAY_REQUIRED, errorLocale)
+            content = localizationService.getString(LocalizationKeys.RADIO_PLAY_REQUIRED, guildId, discordLocale)
         }
     }
 

--- a/src/main/kotlin/commands/radio/subcommands/random/RadioRandomCommand.kt
+++ b/src/main/kotlin/commands/radio/subcommands/random/RadioRandomCommand.kt
@@ -13,7 +13,6 @@ import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.services.radio.RadioService
-import es.wokis.utils.orDefaultLocale
 
 class RadioRandomCommand(
     private val radioService: RadioService,
@@ -23,7 +22,7 @@ class RadioRandomCommand(
 
     override suspend fun onRegisterCommand(builder: GlobalChatInputCreateBuilder) {
         builder.apply {
-            subCommand(CommandName.Radio.Random.commandName, localizationService.getString(LocalizationKeys.RADIO_RANDOM_COMMAND_DESCRIPTION)) {
+            subCommand(CommandName.Radio.Random.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_RANDOM_COMMAND_DESCRIPTION).values.first()) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_RANDOM_COMMAND_DESCRIPTION)
             }
         }
@@ -33,13 +32,15 @@ class RadioRandomCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
 
         response.respond {
             content = localizationService.getString(
                 key = LocalizationKeys.RADIO_RANDOM_SEARCHING,
-                locale = locale
+                guildId = guildId,
+                discordLocale = discordLocale
             )
         }
 
@@ -54,7 +55,8 @@ class RadioRandomCommand(
                 } ?: response.respond {
                     content = localizationService.getString(
                         key = LocalizationKeys.RADIO_RANDOM_ERROR,
-                        locale = locale
+                        guildId = guildId,
+                        discordLocale = discordLocale
                     )
                 }
             }
@@ -63,7 +65,8 @@ class RadioRandomCommand(
                 response.respond {
                     content = localizationService.getString(
                         key = LocalizationKeys.RADIO_RANDOM_ERROR,
-                        locale = locale
+                        guildId = guildId,
+                        discordLocale = discordLocale
                     )
                 }
             }

--- a/src/main/kotlin/commands/radio/subcommands/search/RadioSearchGroupCommand.kt
+++ b/src/main/kotlin/commands/radio/subcommands/search/RadioSearchGroupCommand.kt
@@ -26,18 +26,18 @@ class RadioSearchGroupCommand(
 
     override suspend fun onRegisterCommand(builder: GlobalChatInputCreateBuilder) {
         builder.apply {
-            group(CommandName.Radio.Search.commandName, localizationService.getString(LocalizationKeys.RADIO_SEARCH_COMMAND_DESCRIPTION)) {
+            group(CommandName.Radio.Search.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_COMMAND_DESCRIPTION).values.first()) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_COMMAND_DESCRIPTION)
-                subCommand(CommandName.Radio.Search.Name.commandName, localizationService.getString(LocalizationKeys.RADIO_SEARCH_NAME_COMMAND_DESCRIPTION)) {
+                subCommand(CommandName.Radio.Search.Name.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_NAME_COMMAND_DESCRIPTION).values.first()) {
                     descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_NAME_COMMAND_DESCRIPTION)
-                    string("name", localizationService.getString(LocalizationKeys.RADIO_SEARCH_NAME_INPUT_DESCRIPTION)) {
+                    string("name", localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_NAME_INPUT_DESCRIPTION).values.first()) {
                         descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_NAME_INPUT_DESCRIPTION)
                         required = true
                     }
                 }
-                subCommand(CommandName.Radio.Search.CountryCode.commandName, localizationService.getString(LocalizationKeys.RADIO_SEARCH_COUNTRYCODE_COMMAND_DESCRIPTION)) {
+                subCommand(CommandName.Radio.Search.CountryCode.commandName, localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_COUNTRYCODE_COMMAND_DESCRIPTION).values.first()) {
                     descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_COUNTRYCODE_COMMAND_DESCRIPTION)
-                    string("countrycode", localizationService.getString(LocalizationKeys.RADIO_SEARCH_COUNTRYCODE_INPUT_DESCRIPTION)) {
+                    string("countrycode", localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_COUNTRYCODE_INPUT_DESCRIPTION).values.first()) {
                         descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RADIO_SEARCH_COUNTRYCODE_INPUT_DESCRIPTION)
                         required = true
                         autocomplete = true

--- a/src/main/kotlin/commands/reconnect/ReconnectCommand.kt
+++ b/src/main/kotlin/commands/reconnect/ReconnectCommand.kt
@@ -9,7 +9,6 @@ import es.wokis.commands.CommandName
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
-import es.wokis.utils.orDefaultLocale
 
 class ReconnectCommand(
     private val guildQueueService: GuildQueueService,
@@ -18,7 +17,7 @@ class ReconnectCommand(
     override fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
         commandBuilder.input(
             name = CommandName.Reconnect.commandName,
-            description = localizationService.getString(LocalizationKeys.RECONNECT_COMMAND_DESCRIPTION)
+            description = localizationService.getLocalizations(LocalizationKeys.RECONNECT_COMMAND_DESCRIPTION).values.first()
         ) {
             descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.RECONNECT_COMMAND_DESCRIPTION)
         }
@@ -28,19 +27,20 @@ class ReconnectCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val lavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
 
         if (!lavaPlayerService.isConnected()) {
             response.respond {
-                content = localizationService.getString(LocalizationKeys.RECONNECT_NOT_CONNECTED, locale)
+                content = localizationService.getString(LocalizationKeys.RECONNECT_NOT_CONNECTED, guildId, discordLocale)
             }
             return
         }
 
         lavaPlayerService.reconnect()
         response.respond {
-            content = localizationService.getString(LocalizationKeys.RECONNECT_SUCCESS, locale)
+            content = localizationService.getString(LocalizationKeys.RECONNECT_SUCCESS, guildId, discordLocale)
         }
     }
 }

--- a/src/main/kotlin/commands/shuffle/ShuffleCommand.kt
+++ b/src/main/kotlin/commands/shuffle/ShuffleCommand.kt
@@ -9,7 +9,6 @@ import es.wokis.commands.CommandName
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
-import es.wokis.utils.orDefaultLocale
 
 class ShuffleCommand(
     private val guildQueueService: GuildQueueService,
@@ -20,7 +19,7 @@ class ShuffleCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Shuffle.commandName,
-                description = localizationService.getString(key = LocalizationKeys.SHUFFLE_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.SHUFFLE_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.SHUFFLE_COMMAND_DESCRIPTION)
             }
@@ -31,13 +30,15 @@ class ShuffleCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
         guildLavaPlayerService.shuffle()
         response.respond {
             content = localizationService.getString(
                 key = LocalizationKeys.SHUFFLE_COMMAND_RESPONSE,
-                locale = locale
+                guildId = guildId,
+                discordLocale = discordLocale
             )
         }
     }

--- a/src/main/kotlin/commands/skip/SkipCommand.kt
+++ b/src/main/kotlin/commands/skip/SkipCommand.kt
@@ -9,7 +9,6 @@ import es.wokis.commands.CommandName
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
-import es.wokis.utils.orDefaultLocale
 
 class SkipCommand(
     private val guildQueueService: GuildQueueService,
@@ -20,7 +19,7 @@ class SkipCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Skip.commandName,
-                description = localizationService.getString(key = LocalizationKeys.SKIP_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.SKIP_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.SKIP_COMMAND_DESCRIPTION)
             }
@@ -31,13 +30,15 @@ class SkipCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction)
         guildLavaPlayerService.skip()
         response.respond {
             content = localizationService.getString(
                 key = LocalizationKeys.SKIP_COMMAND_RESPONSE,
-                locale = locale
+                guildId = guildId,
+                discordLocale = discordLocale
             )
         }
     }

--- a/src/main/kotlin/commands/sound/SoundCommand.kt
+++ b/src/main/kotlin/commands/sound/SoundCommand.kt
@@ -16,7 +16,6 @@ import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.utils.getFolderContent
-import es.wokis.utils.orDefaultLocale
 import es.wokis.utils.takeIfNotEmpty
 import java.io.File
 
@@ -33,12 +32,12 @@ class SoundCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Sound.commandName,
-                description = localizationService.getString(LocalizationKeys.SOUND_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.SOUND_COMMAND_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.SOUND_COMMAND_DESCRIPTION)
                 string(
                     name = ARGUMENT_NAME,
-                    description = localizationService.getString(LocalizationKeys.SOUND_COMMAND_INPUT_DESCRIPTION)
+                    description = localizationService.getLocalizations(LocalizationKeys.SOUND_COMMAND_INPUT_DESCRIPTION).values.first()
                 ) {
                     descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.SOUND_COMMAND_INPUT_DESCRIPTION)
                     required = true
@@ -52,18 +51,24 @@ class SoundCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val soundName: String = interaction.command.strings[ARGUMENT_NAME]?.takeIfNotEmpty()
             ?: response.respond {
                 content = localizationService.getStringFormat(
                     key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(ARGUMENT_NAME)
                 )
             }.let { return }
 
         response.respond {
-            content = localizationService.getString(LocalizationKeys.SEARCHING_SONG, locale)
+            content = localizationService.getString(
+                LocalizationKeys.SEARCHING_SONG,
+                guildId = guildId,
+                discordLocale = discordLocale
+            )
         }
 
         val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
@@ -74,7 +79,8 @@ class SoundCommand(
             response.respond {
                 content = localizationService.getStringFormat(
                     key = LocalizationKeys.NO_MATCHES,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(soundName)
                 )
             }.let { return }

--- a/src/main/kotlin/commands/sounds/SoundsCommand.kt
+++ b/src/main/kotlin/commands/sounds/SoundsCommand.kt
@@ -17,7 +17,6 @@ import es.wokis.constants.BLANK_SPACE
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.utils.getFolderContent
-import es.wokis.utils.orDefaultLocale
 import java.io.File
 
 private const val SOUNDS_PATH = "./audio"
@@ -30,7 +29,7 @@ class SoundsCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Sounds.commandName,
-                description = localizationService.getString(LocalizationKeys.SOUNDS_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.SOUNDS_DESCRIPTION).values.first()
             ) {
                 descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.SOUNDS_DESCRIPTION)
             }
@@ -41,13 +40,15 @@ class SoundsCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val sounds: List<File> = getSoundFilesSorted()
         val displaySounds = getDisplaySounds(sounds).sorted()
-        val title = localizationService.getString(key = LocalizationKeys.SOUNDS_EMBED_TITLE, locale = locale)
+        val title = localizationService.getString(key = LocalizationKeys.SOUNDS_EMBED_TITLE, guildId = guildId, discordLocale = discordLocale)
         val description = localizationService.getStringFormat(
             key = LocalizationKeys.SOUNDS_EMBED_DESCRIPTION,
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             arguments = arrayOf(sounds.size)
         )
         val columns = 3
@@ -55,7 +56,8 @@ class SoundsCommand(
         val pageCount = displaySounds.size / columns
         response.respond {
             createPaginatedEmbedMessage(
-                locale = locale,
+                guildId = guildId,
+                discordLocale = discordLocale,
                 localizationService = localizationService,
                 title = title,
                 description = description,
@@ -70,6 +72,8 @@ class SoundsCommand(
     }
 
     override suspend fun onInteract(interaction: ComponentInteraction) {
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val interactionCustomId = (interaction as? ButtonInteraction)?.component?.customId
         val updatePageBy = if (interactionCustomId == ComponentsEnum.QUEUE_PREVIOUS.customId) -1 else 1
         val sounds: List<File> = getSoundFilesSorted()
@@ -82,6 +86,8 @@ class SoundsCommand(
         val displaySoundsPage = displayQueue.chunked(columns).getOrNull(currentPage - 1)
         updateQueueMessage(
             interaction = interaction,
+            guildId = guildId,
+            discordLocale = discordLocale,
             currentPage = currentPage,
             soundsCount = sounds.size,
             displaySoundsPage = displaySoundsPage,
@@ -116,22 +122,25 @@ class SoundsCommand(
 
     private suspend fun updateQueueMessage(
         interaction: ComponentInteraction,
+        guildId: dev.kord.common.entity.Snowflake?,
+        discordLocale: dev.kord.common.Locale?,
         currentPage: Int,
         soundsCount: Int,
         displaySoundsPage: List<String>?,
         pageCount: Int,
         columns: Int
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
-        val title = localizationService.getString(key = LocalizationKeys.SOUNDS_EMBED_TITLE, locale = locale)
+        val title = localizationService.getString(key = LocalizationKeys.SOUNDS_EMBED_TITLE, guildId = guildId, discordLocale = discordLocale)
         val description = localizationService.getStringFormat(
             key = LocalizationKeys.SOUNDS_EMBED_DESCRIPTION,
-            locale = locale,
+            guildId = guildId,
+            discordLocale = discordLocale,
             arguments = arrayOf(soundsCount)
         )
         interaction.message.edit {
             createPaginatedEmbedMessage(
-                locale = locale,
+                guildId = guildId,
+                discordLocale = discordLocale,
                 localizationService = localizationService,
                 title = title,
                 description = description,

--- a/src/main/kotlin/commands/sounds/SoundsCommand.kt
+++ b/src/main/kotlin/commands/sounds/SoundsCommand.kt
@@ -8,6 +8,8 @@ import dev.kord.core.entity.interaction.ChatInputCommandInteraction
 import dev.kord.core.entity.interaction.ComponentInteraction
 import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
 import dev.kord.rest.builder.message.EmbedBuilder
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
 import es.wokis.commands.Command
 import es.wokis.commands.CommandName
 import es.wokis.commands.Component
@@ -122,8 +124,8 @@ class SoundsCommand(
 
     private suspend fun updateQueueMessage(
         interaction: ComponentInteraction,
-        guildId: dev.kord.common.entity.Snowflake?,
-        discordLocale: dev.kord.common.Locale?,
+        guildId: Snowflake?,
+        discordLocale: Locale?,
         currentPage: Int,
         soundsCount: Int,
         displaySoundsPage: List<String>?,

--- a/src/main/kotlin/commands/tts/TTSCommand.kt
+++ b/src/main/kotlin/commands/tts/TTSCommand.kt
@@ -12,7 +12,6 @@ import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.services.tts.TTSService
 import es.wokis.utils.getArgument
-import es.wokis.utils.orDefaultLocale
 
 private const val TTS_ARGUMENT_NAME = "message"
 
@@ -25,14 +24,14 @@ class TTSCommand(
         commandBuilder.apply {
             input(
                 name = CommandName.Tts.commandName,
-                description = localizationService.getString(key = LocalizationKeys.TTS_COMMAND_DESCRIPTION)
+                description = localizationService.getLocalizations(LocalizationKeys.TTS_COMMAND_DESCRIPTION).values.first()
             ) {
-                descriptionLocalizations = localizationService.getLocalizations(key = LocalizationKeys.TTS_COMMAND_DESCRIPTION)
+                descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.TTS_COMMAND_DESCRIPTION)
                 string(
                     name = TTS_ARGUMENT_NAME,
-                    description = localizationService.getString(key = LocalizationKeys.TTS_COMMAND_INPUT_DESCRIPTION)
+                    description = localizationService.getLocalizations(LocalizationKeys.TTS_COMMAND_INPUT_DESCRIPTION).values.first()
                 ) {
-                    descriptionLocalizations = localizationService.getLocalizations(key = LocalizationKeys.TTS_COMMAND_INPUT_DESCRIPTION)
+                    descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.TTS_COMMAND_INPUT_DESCRIPTION)
                     required = true
                 }
             }
@@ -43,12 +42,14 @@ class TTSCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
         val message: String = interaction.getArgument(TTS_ARGUMENT_NAME)
             ?: response.respond {
                 content = localizationService.getStringFormat(
                     key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(TTS_ARGUMENT_NAME)
                 )
             }.let { return }
@@ -56,7 +57,8 @@ class TTSCommand(
         response.respond {
             content = localizationService.getString(
                 key = LocalizationKeys.TTS_COMMAND_RESPONSE,
-                locale = locale
+                guildId = guildId,
+                discordLocale = discordLocale
             )
         }
         ttsService.loadAndPlayMessage(guildLavaPlayerService, message)

--- a/src/main/kotlin/data/locale/GuildLocale.kt
+++ b/src/main/kotlin/data/locale/GuildLocale.kt
@@ -1,0 +1,90 @@
+package es.wokis.data.locale
+
+import dev.kord.common.Locale
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Data class representing a guild's custom locale preference.
+ * Stored in JSON format for persistence.
+ */
+@Serializable
+data class GuildLocale(
+    @SerialName("guild_id")
+    val guildId: String,
+    @SerialName("locale")
+    val locale: String
+)
+
+/**
+ * Container for all guild locale mappings.
+ * Used for JSON serialization/deserialization.
+ */
+@Serializable
+data class GuildLocalesContainer(
+    @SerialName("guild_locales")
+    val guildLocales: MutableMap<String, String> = mutableMapOf()
+)
+
+/**
+ * Extension function to convert a GuildLocale to a Discord Locale object.
+ */
+fun GuildLocale.toLocale(): Locale = Locale.fromString(locale)
+
+/**
+ * Map of Discord locale codes to Locale objects.
+ * Source: https://discord.com/developers/docs/reference#locales
+ */
+val DISCORD_LOCALE_MAP = mapOf(
+    "da" to Locale.DANISH,
+    "de" to Locale.GERMAN,
+    "en-GB" to Locale.ENGLISH_GREAT_BRITAIN,
+    "en-US" to Locale.ENGLISH_UNITED_STATES,
+    "es-ES" to Locale.SPANISH_SPAIN,
+    "fr" to Locale.FRENCH,
+    "hr" to Locale.CROATIAN,
+    "it" to Locale.ITALIAN,
+    "lt" to Locale.LITHUANIAN,
+    "hu" to Locale.HUNGARIAN,
+    "nl" to Locale.DUTCH,
+    "no" to Locale.NORWEGIAN,
+    "pl" to Locale.POLISH,
+    "pt-BR" to Locale.PORTUGUESE_BRAZIL,
+    "ro" to Locale.ROMANIAN,
+    "fi" to Locale.FINNISH,
+    "sv-SE" to Locale.SWEDISH,
+    "vi" to Locale.VIETNAMESE,
+    "tr" to Locale.TURKISH,
+    "cs" to Locale.CZECH,
+    "el" to Locale.GREEK,
+    "bg" to Locale.BULGARIAN,
+    "ru" to Locale.RUSSIAN,
+    "uk" to Locale.UKRAINIAN,
+    "hi" to Locale.HINDI,
+    "th" to Locale.THAI,
+    "zh-CN" to Locale.CHINESE_CHINA,
+    "ja" to Locale.JAPANESE,
+    "zh-TW" to Locale.CHINESE_TAIWAN,
+    "ko" to Locale.KOREAN
+)
+
+/**
+ * List of all Discord-supported locales for the autocomplete feature.
+ */
+val DISCORD_SUPPORTED_LOCALES = DISCORD_LOCALE_MAP.values.toList()
+
+/**
+ * Reverse map to convert Locale back to its Discord locale code.
+ */
+val LOCALE_TO_CODE_MAP = DISCORD_LOCALE_MAP.entries.associate { it.value to it.key }
+
+/**
+ * Extension function to convert a Locale to its Discord code string.
+ */
+fun Locale.toDiscordCode(): String = LOCALE_TO_CODE_MAP[this]
+    ?: throw IllegalArgumentException("Unknown locale: $this")
+
+/**
+ * Special value to indicate that the locale should be reset to Discord's default.
+ */
+const val RESET_LOCALE_VALUE = "reset"

--- a/src/main/kotlin/data/locale/GuildLocale.kt
+++ b/src/main/kotlin/data/locale/GuildLocale.kt
@@ -18,43 +18,9 @@ data class GuildLocalesContainer(
  * Map of Discord locale codes to Locale objects.
  * Source: https://discord.com/developers/docs/reference#locales
  */
-val DISCORD_LOCALE_MAP = mapOf(
-    "da" to Locale.DANISH,
-    "de" to Locale.GERMAN,
-    "en-GB" to Locale.ENGLISH_GREAT_BRITAIN,
-    "en-US" to Locale.ENGLISH_UNITED_STATES,
-    "es-ES" to Locale.SPANISH_SPAIN,
-    "fr" to Locale.FRENCH,
-    "hr" to Locale.CROATIAN,
-    "it" to Locale.ITALIAN,
-    "lt" to Locale.LITHUANIAN,
-    "hu" to Locale.HUNGARIAN,
-    "nl" to Locale.DUTCH,
-    "no" to Locale.NORWEGIAN,
-    "pl" to Locale.POLISH,
-    "pt-BR" to Locale.PORTUGUESE_BRAZIL,
-    "ro" to Locale.ROMANIAN,
-    "fi" to Locale.FINNISH,
-    "sv-SE" to Locale.SWEDISH,
-    "vi" to Locale.VIETNAMESE,
-    "tr" to Locale.TURKISH,
-    "cs" to Locale.CZECH,
-    "el" to Locale.GREEK,
-    "bg" to Locale.BULGARIAN,
-    "ru" to Locale.RUSSIAN,
-    "uk" to Locale.UKRAINIAN,
-    "hi" to Locale.HINDI,
-    "th" to Locale.THAI,
-    "zh-CN" to Locale.CHINESE_CHINA,
-    "ja" to Locale.JAPANESE,
-    "zh-TW" to Locale.CHINESE_TAIWAN,
-    "ko" to Locale.KOREAN
-)
-
-/**
- * List of all Discord-supported locales for the autocomplete feature.
- */
-val DISCORD_SUPPORTED_LOCALES = DISCORD_LOCALE_MAP.values.toList()
+val DISCORD_LOCALE_MAP = Locale.ALL.associateBy {
+    listOfNotNull(it.language, it.country).joinToString("-")
+}
 
 /**
  * Reverse map to convert Locale back to its Discord locale code.

--- a/src/main/kotlin/data/locale/GuildLocale.kt
+++ b/src/main/kotlin/data/locale/GuildLocale.kt
@@ -5,18 +5,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Data class representing a guild's custom locale preference.
- * Stored in JSON format for persistence.
- */
-@Serializable
-data class GuildLocale(
-    @SerialName("guild_id")
-    val guildId: String,
-    @SerialName("locale")
-    val locale: String
-)
-
-/**
  * Container for all guild locale mappings.
  * Used for JSON serialization/deserialization.
  */
@@ -25,11 +13,6 @@ data class GuildLocalesContainer(
     @SerialName("guild_locales")
     val guildLocales: MutableMap<String, String> = mutableMapOf()
 )
-
-/**
- * Extension function to convert a GuildLocale to a Discord Locale object.
- */
-fun GuildLocale.toLocale(): Locale = Locale.fromString(locale)
 
 /**
  * Map of Discord locale codes to Locale objects.

--- a/src/main/kotlin/di/CommandModule.kt
+++ b/src/main/kotlin/di/CommandModule.kt
@@ -19,10 +19,19 @@ import es.wokis.commands.next.NextCommand
 import es.wokis.commands.reconnect.ReconnectCommand
 import es.wokis.commands.disconnect.DisconnectCommand
 import es.wokis.commands.tts.TTSCommand
+import es.wokis.commands.locale.LocaleCommand
+import es.wokis.domain.locale.GetGuildLocaleUseCase
+import es.wokis.domain.locale.SetGuildLocaleUseCase
+import es.wokis.repositories.locale.LocalJsonLocaleRepository
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val commandModule = module {
+    // Locale Repository and Use Cases
+    singleOf(::LocalJsonLocaleRepository)
+    factoryOf(::GetGuildLocaleUseCase)
+    factoryOf(::SetGuildLocaleUseCase)
     factoryOf(::PlayCommand)
     factoryOf(::SoundCommand)
     factoryOf(::QueueCommand)
@@ -42,4 +51,5 @@ val commandModule = module {
     factoryOf(::RadioSearchCountryCodeCommand)
     factoryOf(::RadioRandomCommand)
     factoryOf(::RadioCountryCodesCommand)
+    factoryOf(::LocaleCommand)
 }

--- a/src/main/kotlin/di/CommandModule.kt
+++ b/src/main/kotlin/di/CommandModule.kt
@@ -20,18 +20,10 @@ import es.wokis.commands.reconnect.ReconnectCommand
 import es.wokis.commands.disconnect.DisconnectCommand
 import es.wokis.commands.tts.TTSCommand
 import es.wokis.commands.locale.LocaleCommand
-import es.wokis.domain.locale.GetGuildLocaleUseCase
-import es.wokis.domain.locale.SetGuildLocaleUseCase
-import es.wokis.repositories.locale.LocalJsonLocaleRepository
 import org.koin.core.module.dsl.factoryOf
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val commandModule = module {
-    // Locale Repository and Use Cases
-    singleOf(::LocalJsonLocaleRepository)
-    factoryOf(::GetGuildLocaleUseCase)
-    factoryOf(::SetGuildLocaleUseCase)
     factoryOf(::PlayCommand)
     factoryOf(::SoundCommand)
     factoryOf(::QueueCommand)

--- a/src/main/kotlin/di/DomainModule.kt
+++ b/src/main/kotlin/di/DomainModule.kt
@@ -1,9 +1,13 @@
 package es.wokis.di
 
 import es.wokis.domain.GetFloweryVoicesUseCase
+import es.wokis.domain.locale.GetGuildLocaleUseCase
+import es.wokis.domain.locale.SetGuildLocaleUseCase
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 val domainModule = module {
     factoryOf(::GetFloweryVoicesUseCase)
+    factoryOf(::GetGuildLocaleUseCase)
+    factoryOf(::SetGuildLocaleUseCase)
 }

--- a/src/main/kotlin/di/RepositoryModule.kt
+++ b/src/main/kotlin/di/RepositoryModule.kt
@@ -1,0 +1,16 @@
+package es.wokis.di
+
+import es.wokis.repositories.locale.LocalJsonLocaleRepository
+import kotlinx.serialization.json.Json
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val repositoryModule = module {
+    single {
+        Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        }
+    }
+    singleOf(::LocalJsonLocaleRepository)
+}

--- a/src/main/kotlin/domain/locale/GetGuildLocaleUseCase.kt
+++ b/src/main/kotlin/domain/locale/GetGuildLocaleUseCase.kt
@@ -20,7 +20,6 @@ class GetGuildLocaleUseCase(
      * @param guildId The guild's unique identifier
      * @return The custom locale if set, null otherwise
      */
-    suspend operator fun invoke(guildId: Snowflake): Locale? {
-        return localeRepository.getGuildLocale(guildId)
-    }
+    suspend operator fun invoke(guildId: Snowflake): Locale? =
+        localeRepository.getGuildLocale(guildId)
 }

--- a/src/main/kotlin/domain/locale/GetGuildLocaleUseCase.kt
+++ b/src/main/kotlin/domain/locale/GetGuildLocaleUseCase.kt
@@ -1,0 +1,26 @@
+package es.wokis.domain.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.repositories.locale.LocalJsonLocaleRepository
+
+/**
+ * Use case for retrieving a guild's custom locale preference.
+ * This use case abstracts the data retrieval logic and allows for easy
+ * switching between different repository implementations.
+ */
+class GetGuildLocaleUseCase(
+    private val localeRepository: LocalJsonLocaleRepository
+) {
+
+    /**
+     * Gets the custom locale for a guild.
+     * If no custom locale is set, returns null (caller should use Discord's default).
+     *
+     * @param guildId The guild's unique identifier
+     * @return The custom locale if set, null otherwise
+     */
+    suspend operator fun invoke(guildId: Snowflake): Locale? {
+        return localeRepository.getGuildLocale(guildId)
+    }
+}

--- a/src/main/kotlin/domain/locale/SetGuildLocaleUseCase.kt
+++ b/src/main/kotlin/domain/locale/SetGuildLocaleUseCase.kt
@@ -1,0 +1,34 @@
+package es.wokis.domain.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.repositories.locale.LocalJsonLocaleRepository
+
+/**
+ * Use case for setting or removing a guild's custom locale preference.
+ * This use case abstracts the data persistence logic and allows for easy
+ * switching between different repository implementations.
+ */
+class SetGuildLocaleUseCase(
+    private val localeRepository: LocalJsonLocaleRepository
+) {
+
+    /**
+     * Sets a custom locale for a guild.
+     *
+     * @param guildId The guild's unique identifier
+     * @param locale The locale to set
+     */
+    suspend operator fun invoke(guildId: Snowflake, locale: Locale) {
+        localeRepository.setGuildLocale(guildId, locale)
+    }
+
+    /**
+     * Removes the custom locale for a guild, reverting to Discord's default.
+     *
+     * @param guildId The guild's unique identifier
+     */
+    suspend fun removeLocale(guildId: Snowflake) {
+        localeRepository.removeGuildLocale(guildId)
+    }
+}

--- a/src/main/kotlin/exceptions/BotExceptions.kt
+++ b/src/main/kotlin/exceptions/BotExceptions.kt
@@ -1,6 +1,7 @@
 package es.wokis.exceptions
 
 import es.wokis.data.response.ErrorType
+import es.wokis.localization.LocalizationKeys
 
 /**
  * Sealed base class for all bot-related exceptions.
@@ -26,7 +27,7 @@ sealed class BotException(
          * Thrown when user is not connected to a voice channel
          */
         class NotInVoiceChannelException(
-            localizationKey: String = "error_not_in_voice_channel",
+            localizationKey: String = LocalizationKeys.ERROR_NO_VOICE_CHANNEL,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -34,7 +35,7 @@ sealed class BotException(
          * Thrown when command is executed outside a guild (server)
          */
         class NotInGuildException(
-            localizationKey: String = "error_not_in_guild",
+            localizationKey: String = LocalizationKeys.ERROR_NO_GUILD,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -42,7 +43,7 @@ sealed class BotException(
          * Thrown when required content/argument is not provided
          */
         class NoContentProvidedException(
-            localizationKey: String = "error_no_content_provided",
+            localizationKey: String = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -50,7 +51,7 @@ sealed class BotException(
          * Thrown when user is not in a text channel
          */
         class NotInTextChannelException(
-            localizationKey: String = "error_not_in_text_channel",
+            localizationKey: String = LocalizationKeys.ERROR_NO_TEXT_CHANNEL,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -58,7 +59,7 @@ sealed class BotException(
          * Thrown when queue is empty and an operation requires items in queue
          */
         class EmptyQueueException(
-            localizationKey: String = "error_empty_queue",
+            localizationKey: String = LocalizationKeys.ERROR_EMPTY_QUEUE,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -66,7 +67,7 @@ sealed class BotException(
          * Thrown when audio playback fails
          */
         class AudioPlaybackException(
-            localizationKey: String = "error_audio_playback",
+            localizationKey: String = LocalizationKeys.ERROR_AUDIO_PLAYBACK,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -74,7 +75,7 @@ sealed class BotException(
          * Thrown when a sound file is not found
          */
         class SoundNotFoundException(
-            localizationKey: String = "error_sound_not_found",
+            localizationKey: String = LocalizationKeys.ERROR_SOUND_NOT_FOUND,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -82,7 +83,7 @@ sealed class BotException(
          * Thrown when track is not found in queue
          */
         class TrackNotFoundException(
-            localizationKey: String = "error_track_not_found",
+            localizationKey: String = LocalizationKeys.ERROR_TRACK_NOT_FOUND,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -90,7 +91,7 @@ sealed class BotException(
          * Thrown when user is not connected to same voice channel as bot
          */
         class NotInSameVoiceChannelException(
-            localizationKey: String = "error_not_in_same_voice_channel",
+            localizationKey: String = LocalizationKeys.ERROR_NOT_IN_SAME_VOICE_CHANNEL,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -98,7 +99,7 @@ sealed class BotException(
          * Thrown when there is no voice connection established
          */
         class NoVoiceConnectionException(
-            localizationKey: String = "error_no_voice_connection",
+            localizationKey: String = LocalizationKeys.ERROR_NO_VOICE_CONNECTION,
             vararg args: Any
         ) : UserException(localizationKey, *args)
 
@@ -106,7 +107,7 @@ sealed class BotException(
          * Thrown when trying to skip but no track is playing
          */
         class NoTrackPlayingException(
-            localizationKey: String = "error_no_track_playing",
+            localizationKey: String = LocalizationKeys.ERROR_NO_TRACK_PLAYING,
             vararg args: Any
         ) : UserException(localizationKey, *args)
     }

--- a/src/main/kotlin/localization/LocalizationKeys.kt
+++ b/src/main/kotlin/localization/LocalizationKeys.kt
@@ -106,4 +106,9 @@ object LocalizationKeys {
     const val ERROR_API_UNEXPECTED = "error_api_unexpected"
     const val ERROR_UNEXPECTED = "error_unexpected"
     const val ERROR_UNEXPECTED_WITH_DEBUG = "error_unexpected_with_debug"
+    const val LOCALE_COMMAND_DESCRIPTION = "locale_command_description"
+    const val LOCALE_COMMAND_INPUT_DESCRIPTION = "locale_command_input_description"
+    const val LOCALE_COMMAND_SUCCESS = "locale_command_success"
+    const val LOCALE_COMMAND_RESET_SUCCESS = "locale_command_reset_success"
+    const val LOCALE_COMMAND_INVALID_LOCALE = "locale_command_invalid_locale"
 }

--- a/src/main/kotlin/repositories/locale/LocalJsonLocaleRepository.kt
+++ b/src/main/kotlin/repositories/locale/LocalJsonLocaleRepository.kt
@@ -4,11 +4,12 @@ import dev.kord.common.Locale
 import dev.kord.common.entity.Snowflake
 import es.wokis.data.locale.GuildLocalesContainer
 import es.wokis.data.locale.toDiscordCode
+import es.wokis.utils.Log
 import es.wokis.utils.getOrCreateFile
-import es.wokis.utils.updateFile
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
 import java.io.File
 
 private const val DATA_PATH = "./data/"
@@ -16,16 +17,19 @@ private const val FILE_NAME = "guild_locales.json"
 
 /**
  * Local JSON implementation of LocaleRepository.
- * Stores guild locale preferences in a JSON file.
+ * Stores guild locale preferences in a JSON file with in-memory caching.
  * This implementation is suitable for single-instance deployments.
  */
-class LocalJsonLocaleRepository {
+class LocalJsonLocaleRepository(
+    private val json: Json
+) {
 
     private val file: File = getOrCreateFile(DATA_PATH, FILE_NAME, null)
     private val mutex = Mutex()
-    private val json = Json {
-        prettyPrint = true
-        ignoreUnknownKeys = true
+    private val guildLocalesMap: MutableMap<String, String> = mutableMapOf()
+
+    init {
+        loadFromFile()
     }
 
     /**
@@ -35,9 +39,14 @@ class LocalJsonLocaleRepository {
      * @return The custom locale if set, null otherwise
      */
     suspend fun getGuildLocale(guildId: Snowflake): Locale? = mutex.withLock {
-        val container = readContainer()
-        val localeString = container.guildLocales[guildId.toString()]
-        localeString?.let { Locale.fromString(it) }
+        guildLocalesMap[guildId.toString()]?.let { localeCode ->
+            try {
+                Locale.fromString(localeCode)
+            } catch (e: Exception) {
+                Log.error("Failed to parse locale '$localeCode' for guild $guildId", e)
+                null
+            }
+        }
     }
 
     /**
@@ -47,9 +56,15 @@ class LocalJsonLocaleRepository {
      * @param locale The locale to set
      */
     suspend fun setGuildLocale(guildId: Snowflake, locale: Locale) = mutex.withLock {
-        val container = readContainer()
-        container.guildLocales[guildId.toString()] = locale.toDiscordCode()
-        writeContainer(container)
+        try {
+            val localeCode = locale.toDiscordCode()
+            guildLocalesMap[guildId.toString()] = localeCode
+            writeToFile()
+            Log.info("Set locale for guild $guildId to $localeCode")
+        } catch (e: Exception) {
+            Log.error("Failed to set locale for guild $guildId", e)
+            throw e
+        }
     }
 
     /**
@@ -58,9 +73,14 @@ class LocalJsonLocaleRepository {
      * @param guildId The guild's unique identifier
      */
     suspend fun removeGuildLocale(guildId: Snowflake) = mutex.withLock {
-        val container = readContainer()
-        container.guildLocales.remove(guildId.toString())
-        writeContainer(container)
+        try {
+            guildLocalesMap.remove(guildId.toString())
+            writeToFile()
+            Log.info("Removed locale for guild $guildId")
+        } catch (e: Exception) {
+            Log.error("Failed to remove locale for guild $guildId", e)
+            throw e
+        }
     }
 
     /**
@@ -69,24 +89,40 @@ class LocalJsonLocaleRepository {
      * @return Map of guild IDs to their custom locales
      */
     suspend fun getAllGuildLocales(): Map<Snowflake, Locale> = mutex.withLock {
-        val container = readContainer()
-        container.guildLocales.mapKeys { Snowflake(it.key.toULong()) }
-            .mapValues { Locale.fromString(it.value) }
+        guildLocalesMap.mapKeys { Snowflake(it.key.toULong()) }
+            .mapValues { (_, localeCode) ->
+                try {
+                    Locale.fromString(localeCode)
+                } catch (e: Exception) {
+                    Log.error("Failed to parse locale '$localeCode'", e)
+                    Locale.ENGLISH_UNITED_STATES
+                }
+            }
     }
 
-    private fun readContainer(): GuildLocalesContainer {
-        return if (file.exists() && file.length() > 0) {
-            try {
-                json.decodeFromString(file.readText())
-            } catch (e: Exception) {
-                GuildLocalesContainer()
-            }
-        } else {
-            GuildLocalesContainer()
+    private fun loadFromFile() {
+        if (!file.exists() || file.length() == 0L) {
+            Log.info("Guild locales file not found or empty, starting with empty map")
+            return
+        }
+
+        try {
+            val container = json.decodeFromString<GuildLocalesContainer>(file.readText())
+            guildLocalesMap.putAll(container.guildLocales)
+            Log.info("Loaded ${guildLocalesMap.size} guild locales from file")
+        } catch (e: Exception) {
+            Log.error("Failed to load guild locales from file, starting with empty map", e)
+            // Continue with empty map
         }
     }
 
-    private fun writeContainer(container: GuildLocalesContainer) {
-        file.updateFile(container)
+    private fun writeToFile() {
+        try {
+            val container = GuildLocalesContainer(guildLocalesMap)
+            file.writeText(json.encodeToString(container))
+        } catch (e: Exception) {
+            Log.error("Failed to write guild locales to file", e)
+            throw e
+        }
     }
 }

--- a/src/main/kotlin/repositories/locale/LocalJsonLocaleRepository.kt
+++ b/src/main/kotlin/repositories/locale/LocalJsonLocaleRepository.kt
@@ -9,7 +9,6 @@ import es.wokis.utils.getOrCreateFile
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.encodeToString
 import java.io.File
 
 private const val DATA_PATH = "./data/"

--- a/src/main/kotlin/repositories/locale/LocalJsonLocaleRepository.kt
+++ b/src/main/kotlin/repositories/locale/LocalJsonLocaleRepository.kt
@@ -1,0 +1,92 @@
+package es.wokis.repositories.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.data.locale.GuildLocalesContainer
+import es.wokis.data.locale.toDiscordCode
+import es.wokis.utils.getOrCreateFile
+import es.wokis.utils.updateFile
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import java.io.File
+
+private const val DATA_PATH = "./data/"
+private const val FILE_NAME = "guild_locales.json"
+
+/**
+ * Local JSON implementation of LocaleRepository.
+ * Stores guild locale preferences in a JSON file.
+ * This implementation is suitable for single-instance deployments.
+ */
+class LocalJsonLocaleRepository {
+
+    private val file: File = getOrCreateFile(DATA_PATH, FILE_NAME, null)
+    private val mutex = Mutex()
+    private val json = Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+    }
+
+    /**
+     * Retrieves the custom locale for a specific guild.
+     *
+     * @param guildId The guild's unique identifier
+     * @return The custom locale if set, null otherwise
+     */
+    suspend fun getGuildLocale(guildId: Snowflake): Locale? = mutex.withLock {
+        val container = readContainer()
+        val localeString = container.guildLocales[guildId.toString()]
+        localeString?.let { Locale.fromString(it) }
+    }
+
+    /**
+     * Sets a custom locale for a specific guild.
+     *
+     * @param guildId The guild's unique identifier
+     * @param locale The locale to set
+     */
+    suspend fun setGuildLocale(guildId: Snowflake, locale: Locale) = mutex.withLock {
+        val container = readContainer()
+        container.guildLocales[guildId.toString()] = locale.toDiscordCode()
+        writeContainer(container)
+    }
+
+    /**
+     * Removes the custom locale for a specific guild, reverting to Discord's default.
+     *
+     * @param guildId The guild's unique identifier
+     */
+    suspend fun removeGuildLocale(guildId: Snowflake) = mutex.withLock {
+        val container = readContainer()
+        container.guildLocales.remove(guildId.toString())
+        writeContainer(container)
+    }
+
+    /**
+     * Retrieves all guild locale mappings.
+     *
+     * @return Map of guild IDs to their custom locales
+     */
+    suspend fun getAllGuildLocales(): Map<Snowflake, Locale> = mutex.withLock {
+        val container = readContainer()
+        container.guildLocales.mapKeys { Snowflake(it.key.toULong()) }
+            .mapValues { Locale.fromString(it.value) }
+    }
+
+    private fun readContainer(): GuildLocalesContainer {
+        return if (file.exists() && file.length() > 0) {
+            try {
+                json.decodeFromString(file.readText())
+            } catch (e: Exception) {
+                GuildLocalesContainer()
+            }
+        } else {
+            GuildLocalesContainer()
+        }
+    }
+
+    private fun writeContainer(container: GuildLocalesContainer) {
+        file.updateFile(container)
+    }
+}

--- a/src/main/kotlin/repositories/locale/LocaleRepository.kt
+++ b/src/main/kotlin/repositories/locale/LocaleRepository.kt
@@ -1,0 +1,42 @@
+package es.wokis.repositories.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+
+/**
+ * Repository interface for managing guild locale preferences.
+ * This abstraction allows for easy switching between different storage implementations
+ * (e.g., local JSON file, database, API backend).
+ */
+interface LocaleRepository {
+
+    /**
+     * Retrieves the custom locale for a specific guild.
+     *
+     * @param guildId The guild's unique identifier
+     * @return The custom locale if set, null otherwise
+     */
+    suspend fun getGuildLocale(guildId: Snowflake): Locale?
+
+    /**
+     * Sets a custom locale for a specific guild.
+     *
+     * @param guildId The guild's unique identifier
+     * @param locale The locale to set
+     */
+    suspend fun setGuildLocale(guildId: Snowflake, locale: Locale)
+
+    /**
+     * Removes the custom locale for a specific guild, reverting to Discord's default.
+     *
+     * @param guildId The guild's unique identifier
+     */
+    suspend fun removeGuildLocale(guildId: Snowflake)
+
+    /**
+     * Retrieves all guild locale mappings.
+     *
+     * @return Map of guild IDs to their custom locales
+     */
+    suspend fun getAllGuildLocales(): Map<Snowflake, Locale>
+}

--- a/src/main/kotlin/services/commands/CommandHandlerService.kt
+++ b/src/main/kotlin/services/commands/CommandHandlerService.kt
@@ -17,6 +17,7 @@ import es.wokis.commands.radio.RadioGroupCommand
 import es.wokis.commands.next.NextCommand
 import es.wokis.commands.disconnect.DisconnectCommand
 import es.wokis.commands.reconnect.ReconnectCommand
+import es.wokis.commands.locale.LocaleCommand
 import es.wokis.commands.shuffle.ShuffleCommand
 import es.wokis.commands.skip.SkipCommand
 import es.wokis.commands.sound.SoundCommand
@@ -55,6 +56,7 @@ class CommandHandlerServiceImpl(
     private val reconnectCommand: ReconnectCommand,
     private val nextCommand: NextCommand,
     private val disconnectCommand: DisconnectCommand,
+    private val localeCommand: LocaleCommand,
     private val radioGroupCommand: RadioGroupCommand,
     private val localizationService: LocalizationService,
     private val errorHandlerService: ErrorHandlerService
@@ -72,6 +74,7 @@ class CommandHandlerServiceImpl(
         reconnectCommand.onRegisterCommand(commandBuilder)
         nextCommand.onRegisterCommand(commandBuilder)
         disconnectCommand.onRegisterCommand(commandBuilder)
+        localeCommand.onRegisterCommand(commandBuilder)
     }
 
     override suspend fun onRegisterGroupCommand(kord: Kord) {
@@ -97,6 +100,7 @@ class CommandHandlerServiceImpl(
                 CommandName.Reconnect.commandName -> reconnectCommand.onExecute(interaction, response)
                 CommandName.Next.commandName -> nextCommand.onExecute(interaction, response)
                 CommandName.Disconnect.commandName -> disconnectCommand.onExecute(interaction, response)
+                CommandName.Locale.commandName -> localeCommand.onExecute(interaction, response)
                 else -> respondUnknownCommand(response, interaction.guildLocale, commandName)
             }
         } catch (exception: Throwable) {
@@ -137,6 +141,7 @@ class CommandHandlerServiceImpl(
             when (commandName) {
                 CommandName.Sound.commandName -> soundCommand.onAutoComplete(interaction)
                 CommandName.Radio.commandName -> radioGroupCommand.onAutoComplete(interaction)
+                CommandName.Locale.commandName -> localeCommand.onAutoComplete(interaction)
             }
         } catch (exception: Throwable) {
             errorHandlerService.handleAutocompleteError(exception, interaction, commandName)

--- a/src/main/kotlin/services/commands/CommandHandlerService.kt
+++ b/src/main/kotlin/services/commands/CommandHandlerService.kt
@@ -101,7 +101,7 @@ class CommandHandlerServiceImpl(
                 CommandName.Next.commandName -> nextCommand.onExecute(interaction, response)
                 CommandName.Disconnect.commandName -> disconnectCommand.onExecute(interaction, response)
                 CommandName.Locale.commandName -> localeCommand.onExecute(interaction, response)
-                else -> respondUnknownCommand(response, interaction.guildLocale, commandName)
+                else -> respondUnknownCommand(response, interaction.data.guildId.value, interaction.guildLocale, commandName)
             }
         } catch (exception: Throwable) {
             errorHandlerService.handleCommandError(exception, interaction, response, commandName)
@@ -150,13 +150,15 @@ class CommandHandlerServiceImpl(
 
     private suspend fun respondUnknownCommand(
         response: DeferredPublicMessageInteractionResponseBehavior,
-        locale: Locale?,
+        guildId: dev.kord.common.entity.Snowflake?,
+        discordLocale: dev.kord.common.Locale?,
         commandName: String
     ) {
         response.respond {
             content = localizationService.getStringFormat(
                 key = LocalizationKeys.UNKNOWN_COMMAND,
-                locale = locale ?: Locale.ENGLISH_UNITED_STATES,
+                guildId = guildId,
+                discordLocale = discordLocale,
                 arguments = arrayOf(commandName)
             )
         }

--- a/src/main/kotlin/services/commands/CommandHandlerService.kt
+++ b/src/main/kotlin/services/commands/CommandHandlerService.kt
@@ -1,6 +1,7 @@
 package es.wokis.services.commands
 
 import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ButtonInteraction
@@ -150,8 +151,8 @@ class CommandHandlerServiceImpl(
 
     private suspend fun respondUnknownCommand(
         response: DeferredPublicMessageInteractionResponseBehavior,
-        guildId: dev.kord.common.entity.Snowflake?,
-        discordLocale: dev.kord.common.Locale?,
+        guildId: Snowflake?,
+        discordLocale: Locale?,
         commandName: String
     ) {
         response.respond {

--- a/src/main/kotlin/services/error/ErrorHandlerService.kt
+++ b/src/main/kotlin/services/error/ErrorHandlerService.kt
@@ -12,7 +12,6 @@ import es.wokis.localization.LocalizationKeys
 import es.wokis.services.config.ConfigService
 import es.wokis.services.localization.LocalizationService
 import es.wokis.utils.Log
-import es.wokis.utils.orDefaultLocale
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -189,7 +188,7 @@ class ErrorHandlerService(
         val guildInfo = if (interaction.data.guildId.value != null) "Guild(${interaction.data.guildId.value})" else "DM"
 
         return buildString {
-            appendLine("**BOT ERROR** \uD83D\uDC80")
+            appendLine("**BOT ERROR** 💀")
             appendLine()
             appendLine("**${interactionType.displayName}:** ${commandName ?: "Unknown"}")
 
@@ -224,14 +223,16 @@ class ErrorHandlerService(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val locale = interaction.guildLocale.orDefaultLocale()
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
 
         val message = when (exception) {
             is BotException.UserException -> {
                 // User errors have localization keys
                 localizationService.getStringFormat(
                     key = exception.localizationKey,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = exception.args
                 )
             }
@@ -240,7 +241,8 @@ class ErrorHandlerService(
                 // API errors - use generic API error message
                 localizationService.getString(
                     key = LocalizationKeys.ERROR_API_UNEXPECTED,
-                    locale = locale
+                    guildId = guildId,
+                    discordLocale = discordLocale
                 )
             }
 
@@ -249,13 +251,15 @@ class ErrorHandlerService(
                 if (configService.config.debug) {
                     localizationService.getStringFormat(
                         key = LocalizationKeys.ERROR_UNEXPECTED_WITH_DEBUG,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(exception.originalException?.message ?: exception.message ?: "Unknown")
                     )
                 } else {
                     localizationService.getString(
                         key = LocalizationKeys.ERROR_UNEXPECTED,
-                        locale = locale
+                        guildId = guildId,
+                        discordLocale = discordLocale
                     )
                 }
             }
@@ -265,13 +269,15 @@ class ErrorHandlerService(
                 if (configService.config.debug) {
                     localizationService.getStringFormat(
                         key = LocalizationKeys.ERROR_UNEXPECTED_WITH_DEBUG,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(exception.message ?: "Unknown")
                     )
                 } else {
                     localizationService.getString(
                         key = LocalizationKeys.ERROR_UNEXPECTED,
-                        locale = locale
+                        guildId = guildId,
+                        discordLocale = discordLocale
                     )
                 }
             }

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -53,7 +53,9 @@ class GuildLavaPlayerService(
     private val textChannel: MessageChannel,
     private val voiceChannel: BaseVoiceChannelBehavior,
     private val audioPlayerManager: AudioPlayerManager,
-    private val localizationService: LocalizationService
+    private val localizationService: LocalizationService,
+    val guildId: dev.kord.common.entity.Snowflake,
+    var discordLocale: dev.kord.common.Locale? = null
 ) : AudioEventAdapter() {
 
     private var voiceConnection: VoiceConnection? = null
@@ -106,11 +108,11 @@ class GuildLavaPlayerService(
     override fun onTrackStart(player: AudioPlayer?, track: AudioTrack?) {
         if (isRetrying) return
         coroutineScope.launch {
-            val locale = voiceChannel.getLocale()
+            discordLocale = voiceChannel.getLocale()
             val voiceChannelName = voiceChannel.asChannel().name
             playerMessage?.let {
                 updateSeekChannel.send(Unit)
-            } ?: sendNowPlayingMessage(locale, voiceChannelName)
+            } ?: sendNowPlayingMessage(discordLocale, voiceChannelName)
         }
     }
 
@@ -145,12 +147,13 @@ class GuildLavaPlayerService(
         audioPlayerManager.loadItemSync(message)?.let { item -> item as? AudioTrack }?.let {
             TrackBO(audioTrack = it)
         }?.let { tts ->
-            val locale = voiceChannel.getLocale()
+            discordLocale = voiceChannel.getLocale()
             connectToVoiceChannel()
             textChannel.createMessage(
                 localizationService.getStringFormat(
                     key = LocalizationKeys.ADDED_TRACK_TO_QUEUE,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(tts.audioTrack.info.title)
                 )
             )
@@ -173,11 +176,12 @@ class GuildLavaPlayerService(
             )
         }?.let {
             connectToVoiceChannel()
-            val locale = voiceChannel.getLocale()
+            discordLocale = voiceChannel.getLocale()
             textChannel.createMessage(
                 localizationService.getStringFormat(
                     key = LocalizationKeys.ADDED_TRACK_TO_QUEUE_WITH_LINK,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(radioName, radioUrl)
                 )
             )
@@ -304,13 +308,14 @@ class GuildLavaPlayerService(
         }
     }
     private suspend fun sendNowPlayingMessage(
-        locale: Locale,
+        discordLocale: Locale?,
         voiceChannelName: String
     ) {
         textChannel.createMessage(
             localizationService.getStringFormat(
                 key = LocalizationKeys.NOW_PLAYING,
-                locale = locale,
+                guildId = guildId,
+                discordLocale = discordLocale,
                 arguments = arrayOf(currentTrack?.getDisplayTrackName().orEmpty(), voiceChannelName)
             )
         )
@@ -351,11 +356,12 @@ class GuildLavaPlayerService(
 
         override fun noMatches() {
             coroutineScope.launch {
-                val locale = voiceChannel.getLocale()
+                discordLocale = voiceChannel.getLocale()
                 textChannel.createMessage(
                     localizationService.getStringFormat(
                         key = LocalizationKeys.NO_MATCHES,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(currentLoadTrack)
                     )
                 )
@@ -380,11 +386,12 @@ class GuildLavaPlayerService(
 
         override fun noMatches() {
             coroutineScope.launch {
-                val locale = voiceChannel.getLocale()
+                discordLocale = voiceChannel.getLocale()
                 textChannel.createMessage(
                     localizationService.getStringFormat(
                         key = LocalizationKeys.NO_MATCHES,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(currentLoadTrack)
                     )
                 )
@@ -400,7 +407,7 @@ class GuildLavaPlayerService(
 
     private fun onTrackLoadedWithCustomName(track: AudioTrack, customName: String) {
         coroutineScope.launch {
-            val locale = voiceChannel.getLocale()
+            discordLocale = voiceChannel.getLocale()
             val currentTrack = TrackBO(
                 customName = customName,
                 audioTrack = track
@@ -408,7 +415,8 @@ class GuildLavaPlayerService(
             textChannel.createMessage(
                 localizationService.getStringFormat(
                     key = LocalizationKeys.ADDED_TRACK_TO_QUEUE,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(currentTrack.getDisplayTrackName())
                 )
             )
@@ -419,12 +427,13 @@ class GuildLavaPlayerService(
 
     private fun onPlaylistLoaded(playlist: AudioPlaylist, addToFront: Boolean = false) {
         coroutineScope.launch {
-            val locale = voiceChannel.getLocale()
+            discordLocale = voiceChannel.getLocale()
             val isCurrentlyPlaying = player.playingTrack != null
             val message = textChannel.createMessage(
                 localizationService.getStringFormat(
                     key = LocalizationKeys.FOUND_TRACK_LIST,
-                    locale = locale,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
                     arguments = arrayOf(playlist.name, playlist.tracks.size)
                 )
             )
@@ -438,13 +447,15 @@ class GuildLavaPlayerService(
                 content = if (playlistUrl?.isValidUrl() == true) {
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_SONGS_TO_QUEUE_WITH_LINK else LocalizationKeys.ADDED_SONGS_TO_QUEUE_WITH_LINK,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(playlist.name, playlistUrl, playlist.tracks.size)
                     )
                 } else {
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_SONGS_TO_QUEUE else LocalizationKeys.ADDED_SONGS_TO_QUEUE,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(playlist.name, playlist.tracks.size)
                     )
                 }
@@ -454,20 +465,22 @@ class GuildLavaPlayerService(
 
     private fun onTrackLoaded(track: AudioTrack, addToFront: Boolean = false) {
         coroutineScope.launch {
-            val locale = voiceChannel.getLocale()
+            discordLocale = voiceChannel.getLocale()
             val currentTrack = TrackBO(audioTrack = track)
             val isCurrentlyPlaying = player.playingTrack != null
             textChannel.createMessage(
                 if (track.info.uri.isValidUrl()) {
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_TO_QUEUE_WITH_LINK else LocalizationKeys.ADDED_TRACK_TO_QUEUE_WITH_LINK,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(currentTrack.getDisplayTrackName(), track.info.uri)
                     )
                 } else {
                     localizationService.getStringFormat(
                         key = if (addToFront) LocalizationKeys.NEXT_ADDED_TO_QUEUE else LocalizationKeys.ADDED_TRACK_TO_QUEUE,
-                        locale = locale,
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         arguments = arrayOf(currentTrack.getDisplayTrackName())
                     )
                 }
@@ -505,11 +518,12 @@ class GuildLavaPlayerService(
 
     private suspend fun onLoadFailed(exception: FriendlyException) {
         Log.error("GuildLavaPlayerService onLoadFailed", exception)
-        val locale = voiceChannel.getLocale()
+        discordLocale = voiceChannel.getLocale()
         textChannel.createMessage(
             localizationService.getStringFormat(
                 key = LocalizationKeys.LOAD_FAILED,
-                locale = locale,
+                guildId = guildId,
+                discordLocale = discordLocale,
                 arguments = arrayOf(exception.message ?: UNKNOWN_ERROR)
             )
         )
@@ -531,9 +545,10 @@ class GuildLavaPlayerService(
             try {
                 it.edit {
                     createPlayerEmbed(
+                        guildId = guildId,
+                        discordLocale = discordLocale,
                         guildName = guildName,
                         localizationService = localizationService,
-                        locale = voiceChannel.getLocale(),
                         currentTrack = currentTrack,
                         queue = queue,
                         isPaused = player.isPaused

--- a/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
+++ b/src/main/kotlin/services/lavaplayer/GuildLavaPlayerService.kt
@@ -13,6 +13,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
 import dev.kord.common.Locale
 import dev.kord.common.annotation.KordVoice
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior
 import dev.kord.core.behavior.channel.connect
 import dev.kord.core.behavior.edit
@@ -55,8 +56,8 @@ class GuildLavaPlayerService(
     private val voiceChannel: BaseVoiceChannelBehavior,
     private val audioPlayerManager: AudioPlayerManager,
     private val localizationService: LocalizationService,
-    val guildId: dev.kord.common.entity.Snowflake,
-    var discordLocale: dev.kord.common.Locale? = null
+    val guildId: Snowflake,
+    var discordLocale: Locale? = null
 ) : AudioEventAdapter() {
 
     private var voiceConnection: VoiceConnection? = null

--- a/src/main/kotlin/services/localization/LocalizationService.kt
+++ b/src/main/kotlin/services/localization/LocalizationService.kt
@@ -1,6 +1,8 @@
 package es.wokis.services.localization
 
 import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.domain.locale.GetGuildLocaleUseCase
 import java.net.URI
 import java.nio.file.FileSystems
 import java.nio.file.Files
@@ -11,18 +13,40 @@ import kotlin.io.path.nameWithoutExtension
 private const val LANG_PATH = "/lang"
 private val LANG_RESOURCE = {}::class.java.getResource(LANG_PATH)
 
-class LocalizationService {
+class LocalizationService(
+    private val getGuildLocaleUseCase: GetGuildLocaleUseCase
+) {
 
     private val localizedStrings: Map<String, List<LocalizedString>> = loadLanguages()
 
     fun getLocalizations(key: String): MutableMap<Locale, String> = localizedStrings[key]?.associate { it.locale to it.value }?.toMutableMap()
         ?: throw NoLocalizationFoundException(key)
 
-    fun getString(key: String, locale: Locale = Locale.ENGLISH_UNITED_STATES): String =
-        localizedStrings[key]?.find { it.locale == locale }?.value ?: getDefaultString(key)
+    suspend fun getString(
+        key: String,
+        guildId: Snowflake? = null,
+        discordLocale: Locale? = null
+    ): String {
+        val effectiveLocale = resolveLocale(guildId, discordLocale)
+        return localizedStrings[key]?.find { it.locale == effectiveLocale }?.value ?: getDefaultString(key)
+    }
 
-    fun getStringFormat(key: String, locale: Locale = Locale.ENGLISH_UNITED_STATES, vararg arguments: Any) =
-        getString(key, locale).format(*arguments)
+    suspend fun getStringFormat(
+        key: String,
+        guildId: Snowflake? = null,
+        discordLocale: Locale? = null,
+        vararg arguments: Any
+    ): String {
+        return getString(key, guildId, discordLocale).format(*arguments)
+    }
+
+    private suspend fun resolveLocale(guildId: Snowflake?, discordLocale: Locale?): Locale {
+        return if (guildId != null) {
+            getGuildLocaleUseCase(guildId) ?: discordLocale ?: Locale.ENGLISH_UNITED_STATES
+        } else {
+            discordLocale ?: Locale.ENGLISH_UNITED_STATES
+        }
+    }
 
     private fun getDefaultString(key: String): String =
         localizedStrings[key]?.find { it.locale == Locale.ENGLISH_UNITED_STATES }?.value

--- a/src/main/kotlin/services/localization/LocalizationService.kt
+++ b/src/main/kotlin/services/localization/LocalizationService.kt
@@ -36,16 +36,12 @@ class LocalizationService(
         guildId: Snowflake? = null,
         discordLocale: Locale? = null,
         vararg arguments: Any
-    ): String {
-        return getString(key, guildId, discordLocale).format(*arguments)
-    }
+    ): String = getString(key, guildId, discordLocale).format(*arguments)
 
-    private suspend fun resolveLocale(guildId: Snowflake?, discordLocale: Locale?): Locale {
-        return if (guildId != null) {
-            getGuildLocaleUseCase(guildId) ?: discordLocale ?: Locale.ENGLISH_UNITED_STATES
-        } else {
-            discordLocale ?: Locale.ENGLISH_UNITED_STATES
-        }
+    private suspend fun resolveLocale(guildId: Snowflake?, discordLocale: Locale?): Locale = if (guildId != null) {
+        getGuildLocaleUseCase(guildId) ?: discordLocale ?: Locale.ENGLISH_UNITED_STATES
+    } else {
+        discordLocale ?: Locale.ENGLISH_UNITED_STATES
     }
 
     private fun getDefaultString(key: String): String =

--- a/src/main/kotlin/services/player/PlayerChannelService.kt
+++ b/src/main/kotlin/services/player/PlayerChannelService.kt
@@ -38,7 +38,7 @@ class PlayerChannelService {
      */
     suspend fun sendPlayerMessage(
         interaction: ApplicationCommandInteraction,
-        buildMessage: MessageCreateBuilder.() -> Unit
+        buildMessage: suspend MessageCreateBuilder.() -> Unit
     ): Result<PlayerChannelResult> {
         return try {
             val guildId = interaction.data.guildId.value

--- a/src/main/kotlin/services/processor/MessageProcessorService.kt
+++ b/src/main/kotlin/services/processor/MessageProcessorService.kt
@@ -1,6 +1,5 @@
 package es.wokis.services.processor
 
-import dev.kord.common.Locale
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.ReactionEmoji
@@ -9,7 +8,6 @@ import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
 import es.wokis.utils.asRegex
 import es.wokis.utils.createCoroutineScope
-import es.wokis.utils.getGuildLocale
 import kotlinx.coroutines.launch
 import java.util.regex.Pattern
 
@@ -97,8 +95,8 @@ class MessageProcessorService(
     fun processMessage(message: Message) {
         if (shouldBeProcessed(message.content)) {
             coroutineScope.launch {
-                val locale = message.getGuildLocale()
-                val processedMessage = getProcessedMessage(message.author?.mention, locale, message.content)
+                val guildId = message.data.guildId.value
+                val processedMessage = getProcessedMessage(message.author?.mention, guildId, message.content)
                 message.delete()
                 message.channel.createMessage(processedMessage)
             }
@@ -113,11 +111,11 @@ class MessageProcessorService(
         return linksToProcess.any { content.contains(it) }
     }
 
-    private fun getProcessedMessage(author: String?, locale: Locale, content: String): String = when {
+    private suspend fun getProcessedMessage(author: String?, guildId: Snowflake?, content: String): String = when {
         twitterLinks.any { content.contains(it) } -> getTwitterProcessedMessage(
             author = author,
             content = content,
-            locale = locale
+            guildId = guildId
         )
 
         instagramLinks.any { content.contains(it) } -> getGenericProcessedMessage(
@@ -125,7 +123,7 @@ class MessageProcessorService(
             content = content,
             links = instagramStartLinks,
             fixedUpUrl = FIXED_UP_INSTAGRAM_URL,
-            locale = locale
+            guildId = guildId
         )
 
         redditLinks.any { content.contains(it) } -> getGenericProcessedMessage(
@@ -133,54 +131,56 @@ class MessageProcessorService(
             content = content,
             links = redditLinks,
             fixedUpUrl = FIXED_UP_REDDIT_URL,
-            locale = locale
+            guildId = guildId
         )
 
         tiktokLinks.any { content.contains(it) } -> getTikTokProcessedMessage(
             author = author,
             content = content,
-            locale = locale
+            guildId = guildId
         )
 
         else -> localizationService.getStringFormat(
             key = LocalizationKeys.MESSAGE_PROCESSOR_INVALID_LINK,
-            locale = locale
+            guildId = guildId,
+            discordLocale = null
         )
     }
 
-    private fun getGenericProcessedMessage(
+    private suspend fun getGenericProcessedMessage(
         author: String?,
         content: String,
         links: List<String>,
         fixedUpUrl: String,
-        locale: Locale
+        guildId: Snowflake?
     ): String {
         val fixedMessage = content.replace(links.asRegex(), fixedUpUrl)
-        return getFixedUpMessage(author, fixedMessage, locale)
+        return getFixedUpMessage(author, fixedMessage, guildId)
     }
 
-    private fun getTikTokProcessedMessage(
+    private suspend fun getTikTokProcessedMessage(
         author: String?,
         content: String,
-        locale: Locale
-    ): String = getFixedUpMessage(author, content.replace("tiktok.com/", FIXED_UP_TIKTOK_URL), locale)
+        guildId: Snowflake?
+    ): String = getFixedUpMessage(author, content.replace("tiktok.com/", FIXED_UP_TIKTOK_URL), guildId)
 
-    private fun getTwitterProcessedMessage(
+    private suspend fun getTwitterProcessedMessage(
         author: String?,
         content: String,
-        locale: Locale
+        guildId: Snowflake?
     ): String {
         // Replace twitter/x domains with girlcockx.com
         // Note: Query parameters are kept as girlcockx.com requires them for embeds
         val fixedMessage = content.replace(twitterLinks.asRegex(), FIXED_UP_TWITTER_URL)
 
-        return getFixedUpMessage(author, fixedMessage, locale)
+        return getFixedUpMessage(author, fixedMessage, guildId)
     }
 
-    private fun getFixedUpMessage(author: String?, fixedMessage: String, locale: Locale) =
+    private suspend fun getFixedUpMessage(author: String?, fixedMessage: String, guildId: Snowflake?) =
         localizationService.getStringFormat(
             key = LocalizationKeys.FIXED_UP_LINK,
-            locale = locale,
+            guildId = guildId,
+            discordLocale = null,
             arguments = arrayOf(author.orEmpty(), fixedMessage)
         )
 }

--- a/src/main/kotlin/services/queue/GuildQueueService.kt
+++ b/src/main/kotlin/services/queue/GuildQueueService.kt
@@ -1,5 +1,6 @@
 package es.wokis.services.queue
 
+import dev.kord.common.Locale
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior
 import dev.kord.core.entity.channel.MessageChannel
@@ -39,7 +40,7 @@ class GuildQueueService(
         guildId: Snowflake,
         textChannel: MessageChannel,
         voiceChannel: BaseVoiceChannelBehavior,
-        discordLocale: dev.kord.common.Locale? = null
+        discordLocale: Locale? = null
     ): GuildLavaPlayerService = guildQueues[guildId]?.apply {
         this.discordLocale = discordLocale
     } ?: createLavaPlayer(
@@ -55,7 +56,7 @@ class GuildQueueService(
         guild: Snowflake,
         textChannel: MessageChannel,
         voiceChannel: BaseVoiceChannelBehavior,
-        discordLocale: dev.kord.common.Locale? = null
+        discordLocale: Locale? = null
     ): GuildLavaPlayerService = GuildLavaPlayerService(
         appDispatchers = appDispatchers,
         textChannel = textChannel,

--- a/src/main/kotlin/services/queue/GuildQueueService.kt
+++ b/src/main/kotlin/services/queue/GuildQueueService.kt
@@ -30,18 +30,23 @@ class GuildQueueService(
         return getOrCreateLavaPlayerService(
             guildId = guildId,
             textChannel = textChannel,
-            voiceChannel = voiceChannel
+            voiceChannel = voiceChannel,
+            discordLocale = interaction.guildLocale
         )
     }
 
     fun getOrCreateLavaPlayerService(
         guildId: Snowflake,
         textChannel: MessageChannel,
-        voiceChannel: BaseVoiceChannelBehavior
-    ): GuildLavaPlayerService = guildQueues[guildId] ?: createLavaPlayer(
+        voiceChannel: BaseVoiceChannelBehavior,
+        discordLocale: dev.kord.common.Locale? = null
+    ): GuildLavaPlayerService = guildQueues[guildId]?.apply {
+        this.discordLocale = discordLocale
+    } ?: createLavaPlayer(
         guild = guildId,
         textChannel = textChannel,
-        voiceChannel = voiceChannel
+        voiceChannel = voiceChannel,
+        discordLocale = discordLocale
     )
 
     fun getLavaPlayerService(guildId: Snowflake): GuildLavaPlayerService? = guildQueues[guildId]
@@ -49,13 +54,16 @@ class GuildQueueService(
     private fun createLavaPlayer(
         guild: Snowflake,
         textChannel: MessageChannel,
-        voiceChannel: BaseVoiceChannelBehavior
+        voiceChannel: BaseVoiceChannelBehavior,
+        discordLocale: dev.kord.common.Locale? = null
     ): GuildLavaPlayerService = GuildLavaPlayerService(
         appDispatchers = appDispatchers,
         textChannel = textChannel,
         voiceChannel = voiceChannel,
         audioPlayerManager = audioPlayerManagerProvider.createAudioPlayerManager(),
-        localizationService = localizationService
+        localizationService = localizationService,
+        guildId = guild,
+        discordLocale = discordLocale
     ).also {
         guildQueues[guild] = it
     }

--- a/src/main/kotlin/utils/LocaleExtensions.kt
+++ b/src/main/kotlin/utils/LocaleExtensions.kt
@@ -1,28 +1,5 @@
 package es.wokis.utils
 
 import dev.kord.common.Locale
-import dev.kord.common.entity.Snowflake
-import es.wokis.domain.locale.GetGuildLocaleUseCase
 
 fun Locale?.orDefaultLocale() = this ?: Locale.ENGLISH_UNITED_STATES
-
-/**
- * Resolves the effective locale for a guild.
- * First checks for a custom guild locale, then falls back to Discord's guild locale.
- *
- * @param guildId The guild's unique identifier
- * @param discordLocale The locale provided by Discord (may be null or default for non-Community guilds)
- * @param getGuildLocaleUseCase Use case for retrieving custom guild locale
- * @return The effective locale to use
- */
-suspend fun resolveGuildLocale(
-    guildId: Snowflake?,
-    discordLocale: Locale?,
-    getGuildLocaleUseCase: GetGuildLocaleUseCase
-): Locale {
-    return if (guildId != null) {
-        getGuildLocaleUseCase(guildId) ?: discordLocale.orDefaultLocale()
-    } else {
-        discordLocale.orDefaultLocale()
-    }
-}

--- a/src/main/kotlin/utils/LocaleExtensions.kt
+++ b/src/main/kotlin/utils/LocaleExtensions.kt
@@ -1,5 +1,28 @@
 package es.wokis.utils
 
 import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.domain.locale.GetGuildLocaleUseCase
 
 fun Locale?.orDefaultLocale() = this ?: Locale.ENGLISH_UNITED_STATES
+
+/**
+ * Resolves the effective locale for a guild.
+ * First checks for a custom guild locale, then falls back to Discord's guild locale.
+ *
+ * @param guildId The guild's unique identifier
+ * @param discordLocale The locale provided by Discord (may be null or default for non-Community guilds)
+ * @param getGuildLocaleUseCase Use case for retrieving custom guild locale
+ * @return The effective locale to use
+ */
+suspend fun resolveGuildLocale(
+    guildId: Snowflake?,
+    discordLocale: Locale?,
+    getGuildLocaleUseCase: GetGuildLocaleUseCase
+): Locale {
+    return if (guildId != null) {
+        getGuildLocaleUseCase(guildId) ?: discordLocale.orDefaultLocale()
+    } else {
+        discordLocale.orDefaultLocale()
+    }
+}

--- a/src/main/resources/lang/lang.yml
+++ b/src/main/resources/lang/lang.yml
@@ -103,3 +103,8 @@ error_no_track_playing: No track is currently playing
 error_api_unexpected: An error occurred while communicating with external services. Please try again later.
 error_unexpected: An unexpected error occurred. Please try again later.
 error_unexpected_with_debug: An unexpected error occurred: %s
+locale_command_description: Set the preferred locale for this guild
+locale_command_input_description: Locale to set (use autocomplete to see available options)
+locale_command_success: Guild locale has been set to %s
+locale_command_reset_success: Guild locale has been reset to Discord's default
+locale_command_invalid_locale: Invalid locale provided. Please use the autocomplete options.

--- a/src/main/resources/lang/lang_es-ES.yml
+++ b/src/main/resources/lang/lang_es-ES.yml
@@ -103,3 +103,8 @@ error_no_track_playing: No hay ninguna pista reproduciéndose
 error_api_unexpected: Ocurrió un error al comunicarse con servicios externos. Por favor, inténtalo de nuevo más tarde.
 error_unexpected: Ocurrió un error inesperado. Por favor, inténtalo de nuevo más tarde.
 error_unexpected_with_debug: Ocurrió un error inesperado: %s
+locale_command_description: Establecer el idioma preferido para este servidor
+locale_command_input_description: Idioma a establecer (usa el autocompletado para ver las opciones disponibles)
+locale_command_success: El idioma del servidor se ha establecido a %s
+locale_command_reset_success: El idioma del servidor se ha restablecido al valor predeterminado de Discord
+locale_command_invalid_locale: Idioma proporcionado no válido. Por favor, usa las opciones de autocompletado.

--- a/src/test/kotlin/commands/disconnect/DisconnectCommandTest.kt
+++ b/src/test/kotlin/commands/disconnect/DisconnectCommandTest.kt
@@ -53,7 +53,7 @@ class DisconnectCommandTest {
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
         coJustRun { guildLavaPlayerService.stop() }
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
 
         // When
         disconnectCommand.onExecute(interaction, response)
@@ -92,7 +92,7 @@ class DisconnectCommandTest {
         val guildLavaPlayerService: GuildLavaPlayerService = mockk()
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } throws IllegalStateException()
         coJustRun { guildLavaPlayerService.stop() }
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
 
         // When/Then - exception is thrown (handled by CommandHandlerService)
         assertThrows<IllegalStateException> {

--- a/src/test/kotlin/commands/locale/LocaleCommandTest.kt
+++ b/src/test/kotlin/commands/locale/LocaleCommandTest.kt
@@ -9,7 +9,6 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import es.wokis.commands.locale.LocaleCommand
 import es.wokis.domain.locale.GetGuildLocaleUseCase
 import es.wokis.domain.locale.SetGuildLocaleUseCase
-import es.wokis.services.localization.GuildLocalizationService
 import es.wokis.services.localization.LocalizationService
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
@@ -18,14 +17,10 @@ import org.junit.jupiter.api.Test
 class LocaleCommandTest {
 
     private val localizationService: LocalizationService = mockk()
-    private val guildLocalizationService: GuildLocalizationService = mockk()
-    private val getGuildLocaleUseCase: GetGuildLocaleUseCase = mockk()
     private val setGuildLocaleUseCase: SetGuildLocaleUseCase = mockk()
 
     private val localeCommand = LocaleCommand(
         localizationService = localizationService,
-        guildLocalizationService = guildLocalizationService,
-        getGuildLocaleUseCase = getGuildLocaleUseCase,
         setGuildLocaleUseCase = setGuildLocaleUseCase
     )
 
@@ -59,7 +54,7 @@ class LocaleCommandTest {
         }
 
         coJustRun { setGuildLocaleUseCase(any(), any()) }
-        coEvery { guildLocalizationService.getStringFormat(any(), any(), any(), any()) } returns "Locale set to es-ES"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), any()) } returns "Locale set to es-ES"
 
         // When
         localeCommand.onExecute(interaction, response)
@@ -100,7 +95,7 @@ class LocaleCommandTest {
         }
 
         coJustRun { setGuildLocaleUseCase.removeLocale(any()) }
-        coEvery { guildLocalizationService.getString(any(), any(), any()) } returns "Locale reset"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Locale reset"
 
         // When
         localeCommand.onExecute(interaction, response)
@@ -140,7 +135,7 @@ class LocaleCommandTest {
             every { token } returns "testToken"
         }
 
-        coEvery { guildLocalizationService.getString(any(), any(), any()) } returns "Invalid locale"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Invalid locale"
 
         // When
         localeCommand.onExecute(interaction, response)
@@ -179,7 +174,7 @@ class LocaleCommandTest {
             every { token } returns "testToken"
         }
 
-        coEvery { guildLocalizationService.getString(any(), any(), any()) } returns "No guild"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No guild"
 
         // When
         localeCommand.onExecute(interaction, response)
@@ -219,7 +214,7 @@ class LocaleCommandTest {
             every { token } returns "testToken"
         }
 
-        coEvery { guildLocalizationService.getStringFormat(any(), any(), any(), any()) } returns "No content provided"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), any()) } returns "No content provided"
 
         // When
         localeCommand.onExecute(interaction, response)

--- a/src/test/kotlin/commands/locale/LocaleCommandTest.kt
+++ b/src/test/kotlin/commands/locale/LocaleCommandTest.kt
@@ -9,10 +9,12 @@ import dev.kord.core.supplier.EntitySupplyStrategy
 import es.wokis.commands.locale.LocaleCommand
 import es.wokis.domain.locale.GetGuildLocaleUseCase
 import es.wokis.domain.locale.SetGuildLocaleUseCase
+import es.wokis.exceptions.BotException
 import es.wokis.services.localization.LocalizationService
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class LocaleCommandTest {
 
@@ -177,7 +179,9 @@ class LocaleCommandTest {
         coEvery { localizationService.getString(any(), any(), any()) } returns "No guild"
 
         // When
-        localeCommand.onExecute(interaction, response)
+        assertThrows<BotException.UserException.NotInGuildException> {
+            localeCommand.onExecute(interaction, response)
+        }
 
         // Then
         coVerify(exactly = 0) {
@@ -217,7 +221,9 @@ class LocaleCommandTest {
         coEvery { localizationService.getStringFormat(any(), any(), any(), any()) } returns "No content provided"
 
         // When
-        localeCommand.onExecute(interaction, response)
+        assertThrows<BotException.UserException.NoContentProvidedException> {
+            localeCommand.onExecute(interaction, response)
+        }
 
         // Then
         coVerify(exactly = 0) {

--- a/src/test/kotlin/commands/locale/LocaleCommandTest.kt
+++ b/src/test/kotlin/commands/locale/LocaleCommandTest.kt
@@ -1,0 +1,232 @@
+package commands.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.supplier.EntitySupplyStrategy
+import es.wokis.commands.locale.LocaleCommand
+import es.wokis.domain.locale.GetGuildLocaleUseCase
+import es.wokis.domain.locale.SetGuildLocaleUseCase
+import es.wokis.services.localization.GuildLocalizationService
+import es.wokis.services.localization.LocalizationService
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class LocaleCommandTest {
+
+    private val localizationService: LocalizationService = mockk()
+    private val guildLocalizationService: GuildLocalizationService = mockk()
+    private val getGuildLocaleUseCase: GetGuildLocaleUseCase = mockk()
+    private val setGuildLocaleUseCase: SetGuildLocaleUseCase = mockk()
+
+    private val localeCommand = LocaleCommand(
+        localizationService = localizationService,
+        guildLocalizationService = guildLocalizationService,
+        getGuildLocaleUseCase = getGuildLocaleUseCase,
+        setGuildLocaleUseCase = setGuildLocaleUseCase
+    )
+
+    @Test
+    fun `Given valid locale When onExecute is called Then set guild locale`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val testGuildId = Snowflake(123)
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns testGuildId
+            }
+            every { kord } returns mockKord
+            every { command } returns mockk {
+                every { strings } returns mapOf("locale" to "es-ES")
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+
+        coJustRun { setGuildLocaleUseCase(any(), any()) }
+        coEvery { guildLocalizationService.getStringFormat(any(), any(), any(), any()) } returns "Locale set to es-ES"
+
+        // When
+        localeCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            setGuildLocaleUseCase(testGuildId, Locale.SPANISH_SPAIN)
+        }
+    }
+
+    @Test
+    fun `Given reset locale When onExecute is called Then remove guild locale`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val testGuildId = Snowflake(123)
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns testGuildId
+            }
+            every { kord } returns mockKord
+            every { command } returns mockk {
+                every { strings } returns mapOf("locale" to "reset")
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+
+        coJustRun { setGuildLocaleUseCase.removeLocale(any()) }
+        coEvery { guildLocalizationService.getString(any(), any(), any()) } returns "Locale reset"
+
+        // When
+        localeCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            setGuildLocaleUseCase.removeLocale(testGuildId)
+        }
+    }
+
+    @Test
+    fun `Given invalid locale When onExecute is called Then show error message`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val testGuildId = Snowflake(123)
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns testGuildId
+            }
+            every { kord } returns mockKord
+            every { command } returns mockk {
+                every { strings } returns mapOf("locale" to "invalid-locale")
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+
+        coEvery { guildLocalizationService.getString(any(), any(), any()) } returns "Invalid locale"
+
+        // When
+        localeCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 0) {
+            setGuildLocaleUseCase(any(), any())
+        }
+    }
+
+    @Test
+    fun `Given null guildId When onExecute is called Then show error message`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
+            every { kord } returns mockKord
+            every { command } returns mockk {
+                every { strings } returns mapOf("locale" to "es-ES")
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+
+        coEvery { guildLocalizationService.getString(any(), any(), any()) } returns "No guild"
+
+        // When
+        localeCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 0) {
+            setGuildLocaleUseCase(any(), any())
+        }
+    }
+
+    @Test
+    fun `Given null locale input When onExecute is called Then show error message`() = runTest {
+        // Given
+        val mockKord: Kord = mockk {
+            every { resources } returns mockk {
+                every { defaultStrategy } returns EntitySupplyStrategy.rest
+            }
+            every { defaultSupplier } returns mockk()
+            every { rest } returns mockk {
+                every { interaction } returns mockk(relaxed = true)
+            }
+        }
+        val testGuildId = Snowflake(123)
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns testGuildId
+            }
+            every { kord } returns mockKord
+            every { command } returns mockk {
+                every { strings } returns emptyMap()
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior> {
+            every { kord } returns mockKord
+            every { applicationId } returns Snowflake(456)
+            every { token } returns "testToken"
+        }
+
+        coEvery { guildLocalizationService.getStringFormat(any(), any(), any(), any()) } returns "No content provided"
+
+        // When
+        localeCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 0) {
+            setGuildLocaleUseCase(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/commands/next/NextCommandTest.kt
+++ b/src/test/kotlin/commands/next/NextCommandTest.kt
@@ -37,6 +37,9 @@ class NextCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             justRun { loadAndPlay(any(), any()) }
@@ -53,8 +56,8 @@ class NextCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         nextCommand.onExecute(interaction, mockedResponse)
@@ -79,6 +82,9 @@ class NextCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             justRun { loadAndPlay(any(), any()) }
@@ -95,8 +101,8 @@ class NextCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         nextCommand.onExecute(interaction, mockedResponse)
@@ -121,6 +127,9 @@ class NextCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val mockTrack: TrackBO = mockk(relaxed = true)
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
@@ -138,8 +147,8 @@ class NextCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         nextCommand.onExecute(interaction, mockedResponse)
@@ -168,6 +177,9 @@ class NextCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             every { isQueueEmpty() } returns false
@@ -185,8 +197,8 @@ class NextCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         nextCommand.onExecute(interaction, mockedResponse)
@@ -213,6 +225,9 @@ class NextCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             every { isQueueEmpty() } returns true
@@ -228,8 +243,8 @@ class NextCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         nextCommand.onExecute(interaction, mockedResponse)
@@ -257,11 +272,14 @@ class NextCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         nextCommand.onExecute(interaction, mockedResponse)

--- a/src/test/kotlin/commands/play/PlayCommandTest.kt
+++ b/src/test/kotlin/commands/play/PlayCommandTest.kt
@@ -74,6 +74,9 @@ class PlayCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             justRun { loadAndPlayMultiple(any()) }
@@ -89,8 +92,8 @@ class PlayCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         playCommand.onExecute(interaction, mockedResponse)
 
@@ -113,6 +116,9 @@ class PlayCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             justRun { loadAndPlayMultiple(any()) }
@@ -128,8 +134,8 @@ class PlayCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         playCommand.onExecute(interaction, mockedResponse)
@@ -154,6 +160,9 @@ class PlayCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             justRun { loadAndPlayMultiple(any()) }
@@ -169,8 +178,8 @@ class PlayCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         playCommand.onExecute(interaction, mockedResponse)
@@ -194,6 +203,9 @@ class PlayCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             justRun { loadAndPlayMultiple(any()) }
@@ -209,8 +221,8 @@ class PlayCommandTest {
             )
         } returns lavaPlayerService
         every { interaction.guildLocale } returns Locale.ENGLISH_UNITED_STATES
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         // When
         playCommand.onExecute(interaction, mockedResponse)

--- a/src/test/kotlin/commands/player/PlayerCommandTest.kt
+++ b/src/test/kotlin/commands/player/PlayerCommandTest.kt
@@ -91,8 +91,8 @@ class PlayerCommandTest {
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
         coEvery { playerChannelService.sendPlayerMessage(any(), any()) } returns Result.success(playerChannelResult)
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         playerCommand.onExecute(interaction, response)
@@ -142,8 +142,8 @@ class PlayerCommandTest {
         }
 
         coEvery { guildQueueService.getLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         playerCommand.onInteract(interaction)
@@ -191,8 +191,8 @@ class PlayerCommandTest {
         }
 
         coEvery { guildQueueService.getLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         playerCommand.onInteract(interaction)
@@ -240,8 +240,8 @@ class PlayerCommandTest {
         }
 
         coEvery { guildQueueService.getLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         playerCommand.onInteract(interaction)
@@ -289,8 +289,8 @@ class PlayerCommandTest {
         }
 
         coEvery { guildQueueService.getLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         playerCommand.onInteract(interaction)
@@ -341,8 +341,8 @@ class PlayerCommandTest {
         }
 
         coEvery { guildQueueService.getLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         playerCommand.onInteract(interaction)

--- a/src/test/kotlin/commands/queue/QueueCommandTest.kt
+++ b/src/test/kotlin/commands/queue/QueueCommandTest.kt
@@ -16,6 +16,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.coEvery as coEvery
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -61,8 +62,8 @@ class QueueCommandTest {
         }
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         queueCommand.onExecute(interaction, response)
@@ -104,8 +105,8 @@ class QueueCommandTest {
         }
 
         coEvery { guildQueueService.getLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         queueCommand.onInteract(interaction)

--- a/src/test/kotlin/commands/radio/RadioGroupCommandTest.kt
+++ b/src/test/kotlin/commands/radio/RadioGroupCommandTest.kt
@@ -1,5 +1,6 @@
 package commands.radio
 
+import dev.kord.common.Locale
 import dev.kord.core.entity.interaction.AutoCompleteInteraction
 import dev.kord.core.entity.interaction.ButtonInteraction
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
@@ -14,6 +15,7 @@ import es.wokis.commands.radio.subcommands.play.RadioPlayCommand
 import es.wokis.commands.radio.subcommands.random.RadioRandomCommand
 import es.wokis.commands.radio.subcommands.search.RadioSearchGroupCommand
 import es.wokis.services.localization.LocalizationService
+import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
@@ -44,8 +46,8 @@ class RadioGroupCommandTest {
         coJustRun { onExecute(any(), any()) }
     }
     private val localizationService: LocalizationService = mockk {
-        every { getString(any(), any()) } returns "Unknown command"
-        every { getString(any()) } returns "Description"
+        coEvery { getString(any(), any(), any()) } returns "Unknown command"
+        coEvery { getString(any(), any(), any()) } returns "Description"
         every { getLocalizations(any()) } returns mutableMapOf()
     }
 
@@ -66,6 +68,10 @@ class RadioGroupCommandTest {
             every { command } returns mockk<SubCommand> {
                 every { name } returns commandName
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
         }
 
         // When
@@ -85,6 +91,10 @@ class RadioGroupCommandTest {
             every { command } returns mockk<SubCommand> {
                 every { name } returns commandName
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
         }
 
         // When
@@ -104,6 +114,10 @@ class RadioGroupCommandTest {
             every { command } returns mockk<GroupCommand> {
                 every { groupName } returns commandName
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
         }
 
         // When
@@ -123,6 +137,10 @@ class RadioGroupCommandTest {
             every { command } returns mockk<SubCommand> {
                 every { name } returns commandName
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
         }
 
         // When
@@ -142,6 +160,10 @@ class RadioGroupCommandTest {
             every { command } returns mockk<SubCommand> {
                 every { name } returns commandName
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
         }
 
         // When
@@ -160,6 +182,10 @@ class RadioGroupCommandTest {
             every { command } returns mockk<SubCommand> {
                 every { name } returns "unknown"
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
         }
 
         // When

--- a/src/test/kotlin/commands/radio/subcommands/countrycodes/RadioCountryCodesCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/countrycodes/RadioCountryCodesCommandTest.kt
@@ -34,14 +34,17 @@ class RadioCountryCodesCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
             radioService.getCountryCodes()
         } returns RemoteResponse.Success(countryCodes)
 
-        every { localizationService.getString(any(), any()) } returns "Available Country Codes"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Page 1 of 1"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Available Country Codes"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Page 1 of 1"
 
         // When
         radioCountryCodesCommand.onExecute(interaction, mockedResponse)
@@ -58,14 +61,17 @@ class RadioCountryCodesCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
             radioService.getCountryCodes()
         } returns RemoteResponse.Success(RadioCountryCodeDTO(countryCodes = emptyList()))
 
-        every { localizationService.getString(any(), any()) } returns "No country codes available"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Available country codes: "
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No country codes available"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Available country codes: "
 
         // When
         radioCountryCodesCommand.onExecute(interaction, mockedResponse)
@@ -82,13 +88,16 @@ class RadioCountryCodesCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
             radioService.getCountryCodes()
         } returns RemoteResponse.Error(ErrorType.UnknownError(Exception("API Error"), "API Error"))
 
-        every { localizationService.getString(any(), any()) } returns "Error retrieving country codes"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Error retrieving country codes"
 
         // When
         radioCountryCodesCommand.onExecute(interaction, mockedResponse)

--- a/src/test/kotlin/commands/radio/subcommands/list/RadioListCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/list/RadioListCommandTest.kt
@@ -55,14 +55,17 @@ class RadioListCommandTest {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
             every { locale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
             radioService.getRadioList(1)
         } returns RemoteResponse.Success(radioPage)
 
-        every { localizationService.getString(any(), any()) } returns "Radio List"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Page 1 of 5"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Radio List"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Page 1 of 5"
         every { localizationService.getLocalizations(any()) } returns mutableMapOf()
 
         // When
@@ -86,14 +89,17 @@ class RadioListCommandTest {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
             every { locale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
             radioService.getRadioList(1)
         } returns RemoteResponse.Success(emptyPage)
 
-        every { localizationService.getString(any(), any()) } returns "No radios available"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Page 1 of 1"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No radios available"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Page 1 of 1"
         every { localizationService.getLocalizations(any()) } returns mutableMapOf()
 
         // When

--- a/src/test/kotlin/commands/radio/subcommands/play/RadioPlayCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/play/RadioPlayCommandTest.kt
@@ -47,7 +47,10 @@ class RadioPlayCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-            every { command.strings["radio"] } returns radioName
+            every { command.strings["radio"] } returns null
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             coJustRun { playRadio(any(), any(), any()) }
@@ -61,8 +64,8 @@ class RadioPlayCommandTest {
             radioService.findRadio(radioName)
         } returns radio
 
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Searching..."
-        every { localizationService.getString(any(), any()) } returns "Radio found!"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Searching..."
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Radio found!"
 
         // When
         radioPlayCommand.onExecute(interaction, mockedResponse)
@@ -87,6 +90,9 @@ class RadioPlayCommandTest {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
             every { command.strings["radio"] } returns radioName
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService>()
 
@@ -98,8 +104,8 @@ class RadioPlayCommandTest {
             radioService.findRadio(radioName)
         } returns null
 
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Searching..."
-        every { localizationService.getString(any(), any()) } returns "Radio not found"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Searching..."
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Radio not found"
 
         // When
         radioPlayCommand.onExecute(interaction, mockedResponse)
@@ -116,7 +122,10 @@ class RadioPlayCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-            every { command.strings["radio"] } returns null
+            every { command.strings["radio"] } returns ""
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService>()
 
@@ -124,7 +133,7 @@ class RadioPlayCommandTest {
             guildQueueService.getOrCreateLavaPlayerService(interaction)
         } returns lavaPlayerService
 
-        every { localizationService.getString(any(), any()) } returns "Radio name is required"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Radio name is required"
 
         // When
         radioPlayCommand.onExecute(interaction, mockedResponse)

--- a/src/test/kotlin/commands/radio/subcommands/play/RadioPlayCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/play/RadioPlayCommandTest.kt
@@ -47,7 +47,7 @@ class RadioPlayCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-            every { command.strings["radio"] } returns null
+            every { command.strings["radio"] } returns radioName
             every { data } returns mockk {
                 every { guildId.value } returns null
             }
@@ -122,7 +122,7 @@ class RadioPlayCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-            every { command.strings["radio"] } returns ""
+            every { command.strings["radio"] } returns null
             every { data } returns mockk {
                 every { guildId.value } returns null
             }
@@ -134,6 +134,8 @@ class RadioPlayCommandTest {
         } returns lavaPlayerService
 
         coEvery { localizationService.getString(any(), any(), any()) } returns "Radio name is required"
+        coEvery { localizationService.getStringFormat(any(), any(), any()) } returns "Radio name is required"
+        coEvery { radioService.findRadio(any()) } returns null
 
         // When
         radioPlayCommand.onExecute(interaction, mockedResponse)

--- a/src/test/kotlin/commands/radio/subcommands/random/RadioRandomCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/random/RadioRandomCommandTest.kt
@@ -44,6 +44,9 @@ class RadioRandomCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
             coJustRun { playRadio(any(), any(), any()) }
@@ -57,7 +60,7 @@ class RadioRandomCommandTest {
             radioService.getRandomRadio()
         } returns RemoteResponse.Success(radio)
 
-        every { localizationService.getString(any(), any()) } returns "Searching..."
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Searching..."
 
         // When
         radioRandomCommand.onExecute(interaction, mockedResponse)
@@ -80,6 +83,9 @@ class RadioRandomCommandTest {
         val interaction = mockk<ChatInputCommandInteraction> {
             every { kord } returns mockedKord
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService>()
 
@@ -91,7 +97,7 @@ class RadioRandomCommandTest {
             radioService.getRandomRadio()
         } returns RemoteResponse.Error(ErrorType.UnknownError(Exception("API Error"), "API Error"))
 
-        every { localizationService.getString(any(), any()) } returns "Error"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Error"
 
         // When
         radioRandomCommand.onExecute(interaction, mockedResponse)

--- a/src/test/kotlin/commands/radio/subcommands/search/RadioSearchCountryCodeCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/search/RadioSearchCountryCodeCommandTest.kt
@@ -54,14 +54,17 @@ class RadioSearchCountryCodeCommandTest {
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
             every { locale } returns Locale.ENGLISH_UNITED_STATES
             every { command.strings["countrycode"] } returns countryCode
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
             radioService.searchRadioByCountryCodePaged(countryCode, 1)
         } returns RemoteResponse.Success(radioPage)
 
-        every { localizationService.getString(any(), any()) } returns "Radio List"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Page 1 of 5"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Radio List"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Page 1 of 5"
         every { localizationService.getLocalizations(any()) } returns mutableMapOf()
 
         // When
@@ -81,6 +84,9 @@ class RadioSearchCountryCodeCommandTest {
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
             every { locale } returns Locale.ENGLISH_UNITED_STATES
             every { command.strings["countrycode"] } returns ""
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val emptyPage = RadioPageDTO(
             currentPage = 1,
@@ -92,8 +98,8 @@ class RadioSearchCountryCodeCommandTest {
             radioService.searchRadioByCountryCodePaged("", 1)
         } returns RemoteResponse.Success(emptyPage)
 
-        every { localizationService.getString(any(), any()) } returns "No radios found"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Page 1 of 1"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No radios found"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Page 1 of 1"
         every { localizationService.getLocalizations(any()) } returns mutableMapOf()
 
         // When

--- a/src/test/kotlin/commands/radio/subcommands/search/RadioSearchGroupCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/search/RadioSearchGroupCommandTest.kt
@@ -10,6 +10,7 @@ import es.wokis.commands.radio.subcommands.search.RadioSearchGroupCommand
 import es.wokis.commands.radio.subcommands.search.RadioSearchNameCommand
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.localization.LocalizationService
+import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
@@ -30,7 +31,7 @@ class RadioSearchGroupCommandTest {
         coJustRun { onAutoComplete(any()) }
     }
     private val localizationService: LocalizationService = mockk {
-        every { getString(any(), any()) } returns "Description"
+        coEvery { getString(any(), any(), any()) } returns "Description"
         every { getLocalizations(any()) } returns mutableMapOf()
     }
 

--- a/src/test/kotlin/commands/radio/subcommands/search/RadioSearchNameCommandTest.kt
+++ b/src/test/kotlin/commands/radio/subcommands/search/RadioSearchNameCommandTest.kt
@@ -51,14 +51,17 @@ class RadioSearchNameCommandTest {
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
             every { locale } returns Locale.ENGLISH_UNITED_STATES
             every { command.strings["name"] } returns searchName
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
             radioService.searchRadioByNamePaged(searchName, 1)
         } returns RemoteResponse.Success(radioPage)
 
-        every { localizationService.getString(any(), any()) } returns "Radio Search Results"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Page 1 of 3"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "Radio Search Results"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Page 1 of 3"
         every { localizationService.getLocalizations(any()) } returns mutableMapOf()
 
         // When
@@ -78,6 +81,9 @@ class RadioSearchNameCommandTest {
             every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
             every { locale } returns Locale.ENGLISH_UNITED_STATES
             every { command.strings["name"] } returns ""
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
         val emptyPage = RadioPageDTO(
             currentPage = 1,
@@ -89,8 +95,8 @@ class RadioSearchNameCommandTest {
             radioService.searchRadioByNamePaged("", 1)
         } returns RemoteResponse.Success(emptyPage)
 
-        every { localizationService.getString(any(), any()) } returns "No radios found"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Page 1 of 1"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No radios found"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Page 1 of 1"
         every { localizationService.getLocalizations(any()) } returns mutableMapOf()
 
         // When

--- a/src/test/kotlin/commands/reconnect/ReconnectCommandTest.kt
+++ b/src/test/kotlin/commands/reconnect/ReconnectCommandTest.kt
@@ -54,7 +54,7 @@ class ReconnectCommandTest {
         }
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "NotConnectedMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "NotConnectedMessage"
 
         // When
         reconnectCommand.onExecute(interaction, response)
@@ -95,7 +95,7 @@ class ReconnectCommandTest {
         }
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "ReconnectSuccess"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "ReconnectSuccess"
 
         // When
         reconnectCommand.onExecute(interaction, response)

--- a/src/test/kotlin/commands/shuffle/ShuffleCommandTest.kt
+++ b/src/test/kotlin/commands/shuffle/ShuffleCommandTest.kt
@@ -53,7 +53,7 @@ class ShuffleCommandTest {
         }
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
 
         // When
         shuffleCommand.onExecute(interaction, response)
@@ -92,7 +92,7 @@ class ShuffleCommandTest {
             justRun { shuffle() }
         }
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } throws IllegalStateException()
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
 
         // When/Then
         assertThrows<IllegalStateException> {

--- a/src/test/kotlin/commands/skip/SkipCommandTest.kt
+++ b/src/test/kotlin/commands/skip/SkipCommandTest.kt
@@ -54,7 +54,7 @@ class SkipCommandTest {
         }
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
 
         // When
         skipCommand.onExecute(interaction, response)
@@ -94,7 +94,7 @@ class SkipCommandTest {
             justRun { skip() }
         }
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } throws IllegalStateException()
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
 
         // When/Then - exception is thrown (handled by CommandHandlerService)
         assertThrows<IllegalStateException> {

--- a/src/test/kotlin/commands/sound/SoundCommandTest.kt
+++ b/src/test/kotlin/commands/sound/SoundCommandTest.kt
@@ -43,8 +43,8 @@ class SoundCommandTest {
     @BeforeEach
     fun setup() {
         mockkStatic(ChatInputCommandInteraction::getMemberVoiceChannel)
-        every { localizationService.getString(any(), any()) } returns ""
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
 
         testAudioDir.mkdirs()
         testAudioFile.createNewFile()
@@ -67,6 +67,9 @@ class SoundCommandTest {
             every { channel } returns mockedTextChannel
             every { command } returns mockk {
                 every { strings } returns mockedStrings
+            }
+            every { data } returns mockk {
+                every { guildId.value } returns null
             }
         }
         val lavaPlayerService = mockk<GuildLavaPlayerService> {
@@ -106,6 +109,9 @@ class SoundCommandTest {
             every { command } returns mockk {
                 every { strings } returns mockedStrings
             }
+            every { data } returns mockk {
+                every { guildId.value } returns null
+            }
         }
 
         coEvery {
@@ -131,6 +137,9 @@ class SoundCommandTest {
             every { channel } returns mockedTextChannel
             every { command } returns mockk {
                 every { strings } returns mockedStrings
+            }
+            every { data } returns mockk {
+                every { guildId.value } returns null
             }
         }
 
@@ -158,6 +167,9 @@ class SoundCommandTest {
             every { channel } returns mockedTextChannel
             every { command } returns mockk {
                 every { strings } returns mockedStrings
+            }
+            every { data } returns mockk {
+                every { guildId.value } returns null
             }
         }
 
@@ -232,6 +244,9 @@ class SoundCommandTest {
             every { channel } returns mockedTextChannel
             every { command } returns mockk {
                 every { strings } returns mockedStrings
+            }
+            every { data } returns mockk {
+                every { guildId.value } returns null
             }
         }
 

--- a/src/test/kotlin/commands/sounds/SoundsCommandTest.kt
+++ b/src/test/kotlin/commands/sounds/SoundsCommandTest.kt
@@ -62,8 +62,8 @@ class SoundsCommandTest {
             every { token } returns "testToken"
         }
 
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
         // When
         soundsCommand.onExecute(interaction, response)
@@ -103,8 +103,8 @@ class SoundsCommandTest {
                 every { message } returns mockk(relaxed = true)
             }
 
-            every { localizationService.getString(any(), any()) } returns "TestMessage"
-            every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+            coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+            coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
             // When
             soundsCommand.onInteract(interaction)
@@ -145,8 +145,8 @@ class SoundsCommandTest {
                 every { message } returns mockk(relaxed = true)
             }
 
-            every { localizationService.getString(any(), any()) } returns "TestMessage"
-            every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns "Format"
+            coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+            coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Format"
 
             // When
             soundsCommand.onInteract(interaction)

--- a/src/test/kotlin/commands/tts/TTSCommandTest.kt
+++ b/src/test/kotlin/commands/tts/TTSCommandTest.kt
@@ -46,10 +46,10 @@ class TTSCommandTest {
 
     @Test
     @Ignore("Mockk fails")
-    fun `Given tts command When onRegisterCommand is called Then command is registered`() {
+    fun `Given tts command When onRegisterCommand is called Then command is registered`() = runTest {
         // Given
         val commandBuilder = mockk<GlobalMultiApplicationCommandBuilder>(relaxed = true)
-        every { localizationService.getString(any()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns ""
         every { localizationService.getLocalizations(any()) } returns mutableMapOf()
 
         // When
@@ -59,16 +59,14 @@ class TTSCommandTest {
         verify(exactly = 1) {
             commandBuilder.input(
                 name = CommandName.Tts.commandName,
-                description = localizationService.getString(key = LocalizationKeys.TTS_COMMAND_DESCRIPTION)
+                description = ""
             ) {
-                descriptionLocalizations =
-                    localizationService.getLocalizations(key = LocalizationKeys.TTS_COMMAND_DESCRIPTION)
+                descriptionLocalizations = mutableMapOf()
                 string(
                     name = TTS_ARGUMENT_NAME,
-                    description = localizationService.getString(key = LocalizationKeys.TTS_COMMAND_INPUT_DESCRIPTION)
+                    description = ""
                 ) {
-                    descriptionLocalizations =
-                        localizationService.getLocalizations(key = LocalizationKeys.TTS_COMMAND_INPUT_DESCRIPTION)
+                    descriptionLocalizations = mutableMapOf()
                     required = true
                 }
             }
@@ -106,7 +104,7 @@ class TTSCommandTest {
         val guildLavaPlayerService: GuildLavaPlayerService = mockk()
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
         coJustRun { ttsService.loadAndPlayMessage(any(), any()) }
 
         // When
@@ -149,8 +147,8 @@ class TTSCommandTest {
         val guildLavaPlayerService: GuildLavaPlayerService = mockk()
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
         coJustRun { ttsService.loadAndPlayMessage(any(), any()) }
 
         // When
@@ -192,8 +190,8 @@ class TTSCommandTest {
         }
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } throws IllegalStateException()
-        every { localizationService.getString(any(), any()) } returns "TestMessage"
-        every { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns ""
+        coEvery { localizationService.getString(any(), any(), any()) } returns "TestMessage"
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns ""
         coJustRun { ttsService.loadAndPlayMessage(any(), any()) }
 
         // When

--- a/src/test/kotlin/domain/locale/GetGuildLocaleUseCaseTest.kt
+++ b/src/test/kotlin/domain/locale/GetGuildLocaleUseCaseTest.kt
@@ -1,0 +1,48 @@
+package domain.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.domain.locale.GetGuildLocaleUseCase
+import es.wokis.repositories.locale.LocalJsonLocaleRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class GetGuildLocaleUseCaseTest {
+
+    private val localeRepository: LocalJsonLocaleRepository = mockk()
+    private val getGuildLocaleUseCase = GetGuildLocaleUseCase(localeRepository)
+
+    @Test
+    fun `Given guild has custom locale When invoke is called Then return custom locale`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+        val expectedLocale = Locale.SPANISH_SPAIN
+        coEvery { localeRepository.getGuildLocale(guildId) } returns expectedLocale
+
+        // When
+        val result = getGuildLocaleUseCase(guildId)
+
+        // Then
+        assertEquals(expectedLocale, result)
+        coVerify(exactly = 1) { localeRepository.getGuildLocale(guildId) }
+    }
+
+    @Test
+    fun `Given guild has no custom locale When invoke is called Then return null`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+        coEvery { localeRepository.getGuildLocale(guildId) } returns null
+
+        // When
+        val result = getGuildLocaleUseCase(guildId)
+
+        // Then
+        assertNull(result)
+        coVerify(exactly = 1) { localeRepository.getGuildLocale(guildId) }
+    }
+}

--- a/src/test/kotlin/domain/locale/SetGuildLocaleUseCaseTest.kt
+++ b/src/test/kotlin/domain/locale/SetGuildLocaleUseCaseTest.kt
@@ -1,0 +1,41 @@
+package domain.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.domain.locale.SetGuildLocaleUseCase
+import es.wokis.repositories.locale.LocalJsonLocaleRepository
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class SetGuildLocaleUseCaseTest {
+
+    private val localeRepository: LocalJsonLocaleRepository = mockk(relaxed = true)
+    private val setGuildLocaleUseCase = SetGuildLocaleUseCase(localeRepository)
+
+    @Test
+    fun `Given guild and locale When invoke is called Then save locale`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+        val locale = Locale.SPANISH_SPAIN
+
+        // When
+        setGuildLocaleUseCase(guildId, locale)
+
+        // Then
+        coVerify(exactly = 1) { localeRepository.setGuildLocale(guildId, locale) }
+    }
+
+    @Test
+    fun `Given guild When removeLocale is called Then remove locale`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+
+        // When
+        setGuildLocaleUseCase.removeLocale(guildId)
+
+        // Then
+        coVerify(exactly = 1) { localeRepository.removeGuildLocale(guildId) }
+    }
+}

--- a/src/test/kotlin/exceptions/BotExceptionsTest.kt
+++ b/src/test/kotlin/exceptions/BotExceptionsTest.kt
@@ -3,6 +3,7 @@ package exceptions
 import es.wokis.data.response.ErrorType
 import es.wokis.exceptions.BotException
 import es.wokis.exceptions.toException
+import es.wokis.localization.LocalizationKeys
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -18,8 +19,8 @@ class BotExceptionsTest {
         val exception = BotException.UserException.NotInVoiceChannelException()
 
         // Then
-        assertEquals("error_not_in_voice_channel", exception.localizationKey)
-        assertTrue(exception.message?.contains("error_not_in_voice_channel") == true)
+        assertEquals(LocalizationKeys.ERROR_NO_VOICE_CHANNEL, exception.localizationKey)
+        assertTrue(exception.message?.contains(LocalizationKeys.ERROR_NO_VOICE_CHANNEL) == true)
     }
 
     @Test
@@ -38,7 +39,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.NotInGuildException()
 
         // Then
-        assertEquals("error_not_in_guild", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_NO_GUILD, exception.localizationKey)
     }
 
     @Test
@@ -47,7 +48,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.NoContentProvidedException()
 
         // Then
-        assertEquals("error_no_content_provided", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_NO_CONTENT_PROVIDED, exception.localizationKey)
     }
 
     @Test
@@ -56,7 +57,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.NotInTextChannelException()
 
         // Then
-        assertEquals("error_not_in_text_channel", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_NO_TEXT_CHANNEL, exception.localizationKey)
     }
 
     @Test
@@ -65,7 +66,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.EmptyQueueException()
 
         // Then
-        assertEquals("error_empty_queue", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_EMPTY_QUEUE, exception.localizationKey)
     }
 
     @Test
@@ -74,7 +75,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.AudioPlaybackException()
 
         // Then
-        assertEquals("error_audio_playback", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_AUDIO_PLAYBACK, exception.localizationKey)
     }
 
     @Test
@@ -83,7 +84,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.SoundNotFoundException()
 
         // Then
-        assertEquals("error_sound_not_found", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_SOUND_NOT_FOUND, exception.localizationKey)
     }
 
     @Test
@@ -92,7 +93,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.TrackNotFoundException()
 
         // Then
-        assertEquals("error_track_not_found", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_TRACK_NOT_FOUND, exception.localizationKey)
     }
 
     @Test
@@ -101,7 +102,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.NotInSameVoiceChannelException()
 
         // Then
-        assertEquals("error_not_in_same_voice_channel", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_NOT_IN_SAME_VOICE_CHANNEL, exception.localizationKey)
     }
 
     @Test
@@ -110,7 +111,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.NoVoiceConnectionException()
 
         // Then
-        assertEquals("error_no_voice_connection", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_NO_VOICE_CONNECTION, exception.localizationKey)
     }
 
     @Test
@@ -119,7 +120,7 @@ class BotExceptionsTest {
         val exception = BotException.UserException.NoTrackPlayingException()
 
         // Then
-        assertEquals("error_no_track_playing", exception.localizationKey)
+        assertEquals(LocalizationKeys.ERROR_NO_TRACK_PLAYING, exception.localizationKey)
     }
 
     @Test

--- a/src/test/kotlin/repositories/locale/LocalJsonLocaleRepositoryTest.kt
+++ b/src/test/kotlin/repositories/locale/LocalJsonLocaleRepositoryTest.kt
@@ -23,11 +23,13 @@ class LocalJsonLocaleRepositoryTest {
         // Clean up any existing data file to ensure isolated tests
         dataFile.delete()
 
-        // Create repository - it will create the file automatically
-        repository = LocalJsonLocaleRepository(Json {
-            prettyPrint = true
-            ignoreUnknownKeys = true
-        })
+        // Create repository
+        repository = LocalJsonLocaleRepository(
+            Json {
+                prettyPrint = true
+                ignoreUnknownKeys = true
+            }
+        )
     }
 
     @AfterEach
@@ -105,10 +107,12 @@ class LocalJsonLocaleRepositoryTest {
         repository.setGuildLocale(guildId, locale)
 
         // When
-        val newRepository = LocalJsonLocaleRepository(Json {
-            prettyPrint = true
-            ignoreUnknownKeys = true
-        })
+        val newRepository = LocalJsonLocaleRepository(
+            Json {
+                prettyPrint = true
+                ignoreUnknownKeys = true
+            }
+        )
         val result = newRepository.getGuildLocale(guildId)
 
         // Then

--- a/src/test/kotlin/repositories/locale/LocalJsonLocaleRepositoryTest.kt
+++ b/src/test/kotlin/repositories/locale/LocalJsonLocaleRepositoryTest.kt
@@ -1,0 +1,110 @@
+package repositories.locale
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.repositories.locale.LocalJsonLocaleRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class LocalJsonLocaleRepositoryTest {
+
+    private lateinit var repository: LocalJsonLocaleRepository
+    private val dataPath = "./data/"
+    private val fileName = "guild_locales.json"
+    private val dataFile = File(dataPath, fileName)
+
+    @BeforeEach
+    fun setup() {
+        // Clean up any existing data file to ensure isolated tests
+        dataFile.delete()
+        
+        // Create repository - it will create the file automatically
+        repository = LocalJsonLocaleRepository()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        // Clean up data file after each test
+        dataFile.delete()
+    }
+
+    @Test
+    fun `Given no custom locale When getGuildLocale is called Then return null`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+
+        // When
+        val result = repository.getGuildLocale(guildId)
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `Given custom locale set When getGuildLocale is called Then return locale`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+        val locale = Locale.SPANISH_SPAIN
+
+        // When
+        repository.setGuildLocale(guildId, locale)
+        val result = repository.getGuildLocale(guildId)
+
+        // Then
+        assertEquals(locale, result)
+    }
+
+    @Test
+    fun `Given custom locale set When removeGuildLocale is called Then return null`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+        val locale = Locale.SPANISH_SPAIN
+        repository.setGuildLocale(guildId, locale)
+
+        // When
+        repository.removeGuildLocale(guildId)
+        val result = repository.getGuildLocale(guildId)
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `Given multiple guilds When getAllGuildLocales is called Then return all mappings`() = runTest {
+        // Given
+        val guildId1 = Snowflake(123)
+        val guildId2 = Snowflake(456)
+        val locale1 = Locale.SPANISH_SPAIN
+        val locale2 = Locale.FRENCH
+
+        repository.setGuildLocale(guildId1, locale1)
+        repository.setGuildLocale(guildId2, locale2)
+
+        // When
+        val result = repository.getAllGuildLocales()
+
+        // Then
+        assertEquals(2, result.size)
+        assertEquals(locale1, result[guildId1])
+        assertEquals(locale2, result[guildId2])
+    }
+
+    @Test
+    fun `Given locale set When repository recreated Then locale persists`() = runTest {
+        // Given
+        val guildId = Snowflake(123)
+        val locale = Locale.SPANISH_SPAIN
+        repository.setGuildLocale(guildId, locale)
+
+        // When
+        val newRepository = LocalJsonLocaleRepository()
+        val result = newRepository.getGuildLocale(guildId)
+
+        // Then
+        assertEquals(locale, result)
+    }
+}

--- a/src/test/kotlin/repositories/locale/LocalJsonLocaleRepositoryTest.kt
+++ b/src/test/kotlin/repositories/locale/LocalJsonLocaleRepositoryTest.kt
@@ -4,6 +4,7 @@ import dev.kord.common.Locale
 import dev.kord.common.entity.Snowflake
 import es.wokis.repositories.locale.LocalJsonLocaleRepository
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -21,9 +22,12 @@ class LocalJsonLocaleRepositoryTest {
     fun setup() {
         // Clean up any existing data file to ensure isolated tests
         dataFile.delete()
-        
+
         // Create repository - it will create the file automatically
-        repository = LocalJsonLocaleRepository()
+        repository = LocalJsonLocaleRepository(Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        })
     }
 
     @AfterEach
@@ -101,7 +105,10 @@ class LocalJsonLocaleRepositoryTest {
         repository.setGuildLocale(guildId, locale)
 
         // When
-        val newRepository = LocalJsonLocaleRepository()
+        val newRepository = LocalJsonLocaleRepository(Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        })
         val result = newRepository.getGuildLocale(guildId)
 
         // Then

--- a/src/test/kotlin/services/commands/CommandHandlerServiceTest.kt
+++ b/src/test/kotlin/services/commands/CommandHandlerServiceTest.kt
@@ -19,6 +19,7 @@ import es.wokis.commands.sounds.SoundsCommand
 import es.wokis.commands.sound.SoundCommand
 import es.wokis.commands.reconnect.ReconnectCommand
 import es.wokis.commands.tts.TTSCommand
+import es.wokis.commands.locale.LocaleCommand
 import es.wokis.services.commands.CommandHandlerServiceImpl
 import es.wokis.services.error.ErrorHandlerService
 import es.wokis.services.localization.LocalizationService
@@ -39,6 +40,7 @@ class CommandHandlerServiceTest {
     private val reconnectCommand: ReconnectCommand = mockk()
     private val nextCommand: NextCommand = mockk()
     private val disconnectCommand: DisconnectCommand = mockk()
+    private val localeCommand: LocaleCommand = mockk()
     private val localizationService: LocalizationService = mockk()
     private val radioGroupCommand: RadioGroupCommand = mockk()
     private val errorHandlerService: ErrorHandlerService = mockk()
@@ -57,6 +59,7 @@ class CommandHandlerServiceTest {
         reconnectCommand = reconnectCommand,
         nextCommand = nextCommand,
         disconnectCommand = disconnectCommand,
+        localeCommand = localeCommand,
         errorHandlerService = errorHandlerService
     )
 
@@ -79,6 +82,7 @@ class CommandHandlerServiceTest {
         justRun { reconnectCommand.onRegisterCommand(any()) }
         justRun { nextCommand.onRegisterCommand(any()) }
         justRun { disconnectCommand.onRegisterCommand(any()) }
+        justRun { localeCommand.onRegisterCommand(any()) }
 
         // When
         commandHandlerService.onRegisterSimpleCommand(commandBuilder)
@@ -96,6 +100,7 @@ class CommandHandlerServiceTest {
             reconnectCommand.onRegisterCommand(commandBuilder)
             nextCommand.onRegisterCommand(commandBuilder)
             disconnectCommand.onRegisterCommand(commandBuilder)
+            localeCommand.onRegisterCommand(commandBuilder)
         }
     }
 
@@ -310,6 +315,27 @@ class CommandHandlerServiceTest {
     }
 
     @Test
+    fun `Given locale command When onExecute is called Then execute LocaleCommand`() = runTest {
+        // Given
+        val commandName = CommandName.Locale.commandName
+        val interaction: ChatInputCommandInteraction = mockk {
+            every { command } returns mockk {
+                every { rootName } returns commandName
+            }
+        }
+        val response: DeferredPublicMessageInteractionResponseBehavior = mockk()
+        coJustRun { localeCommand.onExecute(any(), any()) }
+
+        // When
+        commandHandlerService.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            localeCommand.onExecute(interaction, response)
+        }
+    }
+
+    @Test
     fun `Given queue previous interaction When onInteract is called Then execute QueueCommand onInteract`() = runTest {
         // Given
         val componentId = ComponentsEnum.QUEUE_PREVIOUS.customId
@@ -422,6 +448,24 @@ class CommandHandlerServiceTest {
         // Then
         coVerify(exactly = 1) {
             radioGroupCommand.onAutoComplete(interaction)
+        }
+    }
+
+    @Test
+    fun `Given locale autocomplete When onAutocomplete is called Then delegate to localeCommand`() = runTest {
+        // Given
+        val commandName = CommandName.Locale.commandName
+        val interaction = mockk<AutoCompleteInteraction> {
+            every { command.rootName } returns commandName
+        }
+        coJustRun { localeCommand.onAutoComplete(any()) }
+
+        // When
+        commandHandlerService.onAutocomplete(interaction)
+
+        // Then
+        coVerify(exactly = 1) {
+            localeCommand.onAutoComplete(interaction)
         }
     }
 }

--- a/src/test/kotlin/services/lavaplayer/GuildLavaPlayerServiceTest.kt
+++ b/src/test/kotlin/services/lavaplayer/GuildLavaPlayerServiceTest.kt
@@ -1,6 +1,7 @@
 package services.lavaplayer
 
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager
+import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior
 import dev.kord.core.entity.channel.MessageChannel
 import es.wokis.services.lavaplayer.GuildLavaPlayerService
@@ -27,7 +28,8 @@ class GuildLavaPlayerServiceTest {
         textChannel = textChannel,
         voiceChannel = voiceChannel,
         audioPlayerManager = audioPlayerManager,
-        localizationService = localizationService
+        localizationService = localizationService,
+        guildId = Snowflake(123)
     )
 
     @Ignore("Cannot test atm")

--- a/src/test/kotlin/services/localization/LocalizationServiceTest.kt
+++ b/src/test/kotlin/services/localization/LocalizationServiceTest.kt
@@ -1,18 +1,24 @@
 package services.localization
 
 import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import es.wokis.domain.locale.GetGuildLocaleUseCase
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.localization.NoLocalizationFoundException
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class LocalizationServiceTest {
 
-    private val localizationService = LocalizationService()
+    private val getGuildLocaleUseCase: GetGuildLocaleUseCase = mockk()
+    private val localizationService = LocalizationService(getGuildLocaleUseCase)
 
     @Test
-    fun `Given key When getString is called Then return default string`() {
+    fun `Given key When getString is called Then return default string`() = runTest {
         // Given
         val key = "test_command_description"
         val expected = "test in junit tests"
@@ -25,26 +31,41 @@ class LocalizationServiceTest {
     }
 
     @Test
-    fun `Given key When getString is called with locale Then return localized string`() {
+    fun `Given key When getString is called with discordLocale Then return localized string`() = runTest {
         // Given
         val key = "test_command_description"
         val expected = "ke dise iyo"
 
         // When
-        val actual = localizationService.getString(key, Locale.SPANISH_SPAIN)
+        val actual = localizationService.getString(key, discordLocale = Locale.SPANISH_SPAIN)
 
         // Then
         assertEquals(expected, actual)
     }
 
     @Test
-    fun `Given key When getString is called with locale without translation Then return default string`() {
+    fun `Given key When getString is called with guildId that has custom locale Then return localized string`() = runTest {
+        // Given
+        val key = "test_command_description"
+        val guildId = Snowflake(123)
+        val expected = "ke dise iyo"
+        coEvery { getGuildLocaleUseCase(guildId) } returns Locale.SPANISH_SPAIN
+
+        // When
+        val actual = localizationService.getString(key, guildId = guildId)
+
+        // Then
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Given key When getString is called with discordLocale without translation Then return default string`() = runTest {
         // Given
         val key = "test_command_description"
         val expected = "test in junit tests"
 
         // When
-        val actual = localizationService.getString(key, Locale.FRENCH)
+        val actual = localizationService.getString(key, discordLocale = Locale.FRENCH)
 
         // Then
         assertEquals(expected, actual)
@@ -63,7 +84,7 @@ class LocalizationServiceTest {
     }
 
     @Test
-    fun `Given invalid key When getString is called Then throw exception`() {
+    fun `Given invalid key When getString is called Then throw exception`() = runTest {
         // Given
         val key = "totally_unknown_key"
 
@@ -77,13 +98,13 @@ class LocalizationServiceTest {
     }
 
     @Test
-    fun `Given invalid key When getString is called with a locale Then throw exception`() {
+    fun `Given invalid key When getString is called with a discordLocale Then throw exception`() = runTest {
         // Given
         val key = "totally_unknown_key"
 
         try {
             // When
-            localizationService.getString(key, Locale.BULGARIAN)
+            localizationService.getString(key, discordLocale = Locale.BULGARIAN)
         } catch (exception: Exception) {
             // Then
             assertTrue(exception is NoLocalizationFoundException)
@@ -105,7 +126,7 @@ class LocalizationServiceTest {
     }
 
     @Test
-    fun `Given key When getStringFormat is called Then return formated string`() {
+    fun `Given key When getStringFormat is called Then return formated string`() = runTest {
         // Given
         val key = "test_args_string"
         val result = "this string has arguments, yay!"
@@ -118,26 +139,41 @@ class LocalizationServiceTest {
     }
 
     @Test
-    fun `Given key When getStringFormat is called with a known locale Then return formated string`() {
+    fun `Given key When getStringFormat is called with a known discordLocale Then return formated string`() = runTest {
         // Given
         val key = "test_args_string"
         val result = "esta string tiene argumentos, yay!"
 
         // When
-        val actual = localizationService.getStringFormat(key, Locale.SPANISH_SPAIN, arguments = arrayOf("yay!"))
+        val actual = localizationService.getStringFormat(key, discordLocale = Locale.SPANISH_SPAIN, arguments = arrayOf("yay!"))
 
         // Then
         assertEquals(result, actual)
     }
 
     @Test
-    fun `Given key When getStringFormat is called with a unregistered locale Then return formated string`() {
+    fun `Given key When getStringFormat is called with a guildId that has custom locale Then return formated string`() = runTest {
+        // Given
+        val key = "test_args_string"
+        val guildId = Snowflake(123)
+        val result = "esta string tiene argumentos, yay!"
+        coEvery { getGuildLocaleUseCase(guildId) } returns Locale.SPANISH_SPAIN
+
+        // When
+        val actual = localizationService.getStringFormat(key, guildId = guildId, arguments = arrayOf("yay!"))
+
+        // Then
+        assertEquals(result, actual)
+    }
+
+    @Test
+    fun `Given key When getStringFormat is called with a unregistered discordLocale Then return formated string`() = runTest {
         // Given
         val key = "test_args_string"
         val result = "this string has arguments, yay!"
 
         // When
-        val actual = localizationService.getStringFormat(key, Locale.FRENCH, arguments = arrayOf("yay!"))
+        val actual = localizationService.getStringFormat(key, discordLocale = Locale.FRENCH, arguments = arrayOf("yay!"))
 
         // Then
         assertEquals(result, actual)

--- a/src/test/kotlin/services/processor/MessageProcessorServiceTest.kt
+++ b/src/test/kotlin/services/processor/MessageProcessorServiceTest.kt
@@ -46,7 +46,7 @@ class MessageProcessorServiceTest {
         }
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://girlcockx.com/status/blablabla"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 
@@ -109,7 +109,7 @@ class MessageProcessorServiceTest {
         }
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://girlcockx.com/elonmusk/status/12345"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 
@@ -147,7 +147,7 @@ class MessageProcessorServiceTest {
         }
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://girlcockx.com/elonmusk/status/12345"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 
@@ -186,7 +186,7 @@ class MessageProcessorServiceTest {
         // Note: Query parameters are kept for girlcockx.com as they are required for embeds
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://girlcockx.com/elonmusk/status/12345?t=abc123&s=19"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 
@@ -249,7 +249,7 @@ class MessageProcessorServiceTest {
         }
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://rxddit.com/blablabla"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 
@@ -287,7 +287,7 @@ class MessageProcessorServiceTest {
         }
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://ddinstagram.com/p/blablabla"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 
@@ -350,7 +350,7 @@ class MessageProcessorServiceTest {
         }
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://vxtiktok.com/blablabla"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 
@@ -388,7 +388,7 @@ class MessageProcessorServiceTest {
         }
         val editedMessage = "Post enviado por $authorMention con el enlace arreglado:\nhttps://vm.vxtiktok.com/blablabla"
 
-        coEvery { localizationService.getStringFormat(any(), any(), *anyVararg()) } returns editedMessage
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns editedMessage
         coJustRun { message.delete() }
         coJustRun { message.channel.createMessage(any()) }
 

--- a/src/test/kotlin/services/queue/GuildQueueServiceTest.kt
+++ b/src/test/kotlin/services/queue/GuildQueueServiceTest.kt
@@ -241,7 +241,7 @@ class GuildQueueServiceTest {
         every { audioPlayerManager.createPlayer() } returns mockk {
             justRun { addListener(any<AudioEventListener>()) }
         }
-        every { localizationService.getString(any(), any()) } returns "No voice channel found"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No voice channel found"
 
         // When/Then
         assertThrows<BotException.UserException.NotInVoiceChannelException> {
@@ -279,7 +279,7 @@ class GuildQueueServiceTest {
                 every { guildId.value } returns mockGuildId
             }
         }
-        every { localizationService.getString(any(), any()) } returns "No text channel found"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No text channel found"
 
         // When/Then
         assertThrows<BotException.UserException.NotInTextChannelException> {
@@ -302,7 +302,7 @@ class GuildQueueServiceTest {
                 every { guildId.value } returns mockGuildId // No guild
             }
         }
-        every { localizationService.getString(any(), any()) } returns "No voice channel found"
+        coEvery { localizationService.getString(any(), any(), any()) } returns "No voice channel found"
 
         // When/Then - When guild is null, getMemberVoiceChannel returns null, so NotInVoiceChannelException is thrown
         assertThrows<BotException.UserException.NotInVoiceChannelException> {


### PR DESCRIPTION
<!-- Change #issue with the issue it is related, if it applies -->
Solves #60.

## 📋 Changelist Summary
Created /locale command to set locale of a guild

## 💬 Description
Created /locale command to set the locale of a given Guild. This locale is saved on a json file inside data. It is read only once when the bot is loaded and kept in memory as a map guildId to locale. 

In this PR we update all commands to support this new usage of LocaleService.