### PR TITLE
Created /ask command with AI provider architecture

### DIFF
--- a/.agents/skills/write-tests/SKILL.md
+++ b/.agents/skills/write-tests/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: write-tests
+description: Load when writing or fixing tests for ECIBotKt. Covers MockK patterns, command/service/HTTP test conventions, interaction mocking, and what not to mock. Only relevant for this project's Kotlin + Kord + Ktor stack.
+---
+
 # Write Tests Skill — ECIBotKt
 
 ## Frameworks

--- a/.agents/skills/write-tests/SKILL.md
+++ b/.agents/skills/write-tests/SKILL.md
@@ -1,0 +1,170 @@
+# Write Tests Skill — ECIBotKt
+
+## Frameworks
+- **Test runner**: Kotlin Test (`kotlin.test.Test`) + JUnit 5 (`org.junit.jupiter.api.Test`)
+- **Mocking**: MockK (`io.mockk.*`)
+- **Coroutines**: `kotlinx.coroutines.test.runTest`
+- **Assertions**: JUnit 5 Assertions (`org.junit.jupiter.api.Assertions.*`) or direct `assertTrue`/`assertEquals` from Kotlin test
+- **HTTP mocking**: Ktor MockEngine via `mock.getMockedHttpClient`
+
+## Test Structure
+
+### Package naming
+Tests mirror the source package under `src/test/kotlin/`:
+```
+src/main/kotlin/commands/tts/TTSCommand.kt → src/test/kotlin/commands/tts/TTSCommandTest.kt
+src/main/kotlin/services/radio/RadioService.kt → src/test/kotlin/services/radio/RadioServiceTest.kt
+```
+
+### Class template
+```kotlin
+package <some>.package
+
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test  // or org.junit.jupiter.api.Test
+
+class FooTest {
+
+    // Dependencies: mockk() each
+    private val dep1 = mockk<Dep1>()
+
+    // SUT
+    private val sut = Foo(dep1)
+
+    @Test
+    fun `Given state When action Then expected result`() = runTest {
+        // Given — arrange mocks
+        coEvery { dep1.something(any()) } returns "value"
+        coJustRun { dep1.voidMethod(any()) }
+
+        // When
+        val result = sut.doSomething()
+
+        // Then — verify
+        assertEquals("expected", result)
+        coVerify(exactly = 1) { dep1.something("arg") }
+        coVerify(exactly = 0) { dep1.otherMethod(any()) }
+    }
+}
+```
+
+## MockK Patterns
+
+### Standard mock
+```kotlin
+val service = mockk<MyService>()
+coEvery { service.method(any()) } returns "result"
+```
+
+### Relaxed mock (for complex objects where you don't care about mock setup)
+```kotlin
+val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+```
+
+### Chained mock config (for config objects)
+```kotlin
+val configService = mockk<ConfigService> {
+    every { config } returns mockk {
+        every { ask } returns mockk {
+            every { enabled } returns true
+        }
+    }
+}
+```
+
+### Void / Unit returning methods
+```kotlin
+coJustRun { service.voidMethod(any()) }
+```
+
+### Throwing
+```kotlin
+coEvery { service.method(any()) } throws IllegalStateException()
+```
+
+### vararg matcher
+```kotlin
+coEvery { service.method(any(), *anyVararg()) } returns "value"
+```
+
+## HTTP Mocking
+Use the existing helper at `src/test/kotlin/mock/HttpClientMock.kt`:
+```kotlin
+import mock.getMockedHttpClient
+
+val httpClient = getMockedHttpClient("""{"key": "value"}""")
+val service = MyService(httpClient)
+```
+This creates a Ktor `HttpClient` with `MockEngine` that always responds with the given JSON content.
+
+## Command Test Patterns
+
+### `onExecute` — verify downstream service calls
+**Don't mock `respond` or `edit` (inline extension functions)** — use `relaxed = true`:
+```kotlin
+val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+coEvery { localizationService.getString(any(), any(), any()) } returns "message"
+coJustRun { service.loadAndPlayMessage(any(), any()) }
+
+sut.onExecute(interaction, response)
+
+coVerify(exactly = 1) { service.loadAndPlayMessage(any(), "expected arg") }
+```
+
+### Error cases — verify service was NOT called
+```kotlin
+sut.onExecute(interaction, response)
+coVerify(exactly = 0) { service.loadAndPlayMessage(any(), any()) }
+```
+
+### `onRegisterCommand` — currently **@Ignored** due to MockK issues
+See `TTSCommandTest.kt` for reference. Don't add new `onRegisterCommand` tests.
+
+## Interaction Mocking
+
+### ChatInputCommandInteraction
+```kotlin
+val interaction = mockk<ChatInputCommandInteraction> {
+    every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+    every { data } returns mockk {
+        every { guildId.value } returns Snowflake(123)
+    }
+    every { command } returns mockk {
+        every { strings } returns mapOf("argName" to "value")
+    }
+}
+```
+
+### MessageCommandInteraction
+```kotlin
+val targetMessage = mockk<Message> {
+    every { content } returns "message content"
+}
+val interaction = mockk<MessageCommandInteraction> {
+    every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+    every { data } returns mockk {
+        every { guildId.value } returns Snowflake(123)
+    }
+    coEvery { getTarget() } returns targetMessage
+}
+```
+
+## Key Imports
+```kotlin
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.entity.interaction.MessageCommandInteraction
+import dev.kord.core.entity.Message
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+```
+
+## Don't
+- ❌ Mock inline extension functions (`respond`, `edit`, `deferPublicResponse`)
+- ❌ Write `onRegisterCommand` tests (MockK can't handle the builder pattern)
+- ❌ Use `@Test` from JUnit 5 and Kotlin test in the same file (pick one)
+- ❌ Import unused Kord entities

--- a/.agents/skills/write-tests/SKILL.md
+++ b/.agents/skills/write-tests/SKILL.md
@@ -1,175 +1,119 @@
 ---
 name: write-tests
-description: Load when writing or fixing tests for ECIBotKt. Covers MockK patterns, command/service/HTTP test conventions, interaction mocking, and what not to mock. Only relevant for this project's Kotlin + Kord + Ktor stack.
+description: "CRITICAL: Load when writing tests for ECIBotKt. Covers MockK patterns, command/service/HTTP mocking, interaction mocks, and pitfalls specific to Kord + Ktor + MockK. Missing this = flaky tests and wasted time."
 ---
 
-# Write Tests Skill — ECIBotKt
+## When to use me
+- After implementing a new command, service, or provider — write tests for it.
+- When fixing a bug — add a test that reproduces the issue first.
+- When CI is failing due to test compilation or coverage drops.
 
-## Frameworks
-- **Test runner**: Kotlin Test (`kotlin.test.Test`) + JUnit 5 (`org.junit.jupiter.api.Test`)
-- **Mocking**: MockK (`io.mockk.*`)
-- **Coroutines**: `kotlinx.coroutines.test.runTest`
-- **Assertions**: JUnit 5 Assertions (`org.junit.jupiter.api.Assertions.*`) or direct `assertTrue`/`assertEquals` from Kotlin test
-- **HTTP mocking**: Ktor MockEngine via `mock.getMockedHttpClient`
+## Not intended for
+- Running tests → use `./gradlew test` directly.
+- Debugging test logic → use IntelliJ debugger.
 
-## Test Structure
+---
 
-### Package naming
-Tests mirror the source package under `src/test/kotlin/`:
-```
-src/main/kotlin/commands/tts/TTSCommand.kt → src/test/kotlin/commands/tts/TTSCommandTest.kt
-src/main/kotlin/services/radio/RadioService.kt → src/test/kotlin/services/radio/RadioServiceTest.kt
-```
+## Test structure
 
-### Class template
+Tests mirror source under `src/test/kotlin/`. File name ends with `Test.kt`.
+
 ```kotlin
-package <some>.package
+package commands.something
 
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test  // or org.junit.jupiter.api.Test
+import kotlin.test.Test
 
 class FooTest {
-
-    // Dependencies: mockk() each
     private val dep1 = mockk<Dep1>()
-
-    // SUT
     private val sut = Foo(dep1)
 
     @Test
-    fun `Given state When action Then expected result`() = runTest {
-        // Given — arrange mocks
-        coEvery { dep1.something(any()) } returns "value"
+    fun `Given state When action Then expected`() = runTest {
+        coEvery { dep1.method(any()) } returns "value"
         coJustRun { dep1.voidMethod(any()) }
 
-        // When
         val result = sut.doSomething()
 
-        // Then — verify
         assertEquals("expected", result)
-        coVerify(exactly = 1) { dep1.something("arg") }
+        coVerify(exactly = 1) { dep1.method("arg") }
         coVerify(exactly = 0) { dep1.otherMethod(any()) }
     }
 }
 ```
 
-## MockK Patterns
+---
 
-### Standard mock
-```kotlin
-val service = mockk<MyService>()
-coEvery { service.method(any()) } returns "result"
-```
+## MockK patterns
 
-### Relaxed mock (for complex objects where you don't care about mock setup)
-```kotlin
-val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
-```
+| Pattern | Syntax |
+|---|---|
+| Standard mock | `val svc = mockk<MyService>()`, `coEvery { svc.foo(any()) } returns "x"` |
+| Relaxed mock | `mockk<ComplexType>(relaxed = true)` — for `respond`/`edit` (inline exts) |
+| Chained config | `mockk<ConfigService> { every { config } returns mockk { every { field } returns value } }` |
+| Void method | `coJustRun { svc.voidMethod(any()) }` |
+| Throw | `coEvery { svc.method(any()) } throws IllegalStateException()` |
+| vararg | `coEvery { svc.method(any(), *anyVararg()) }` |
 
-### Chained mock config (for config objects)
-```kotlin
-val configService = mockk<ConfigService> {
-    every { config } returns mockk {
-        every { ask } returns mockk {
-            every { enabled } returns true
-        }
-    }
-}
-```
+---
 
-### Void / Unit returning methods
-```kotlin
-coJustRun { service.voidMethod(any()) }
-```
+## HTTP mocking
 
-### Throwing
-```kotlin
-coEvery { service.method(any()) } throws IllegalStateException()
-```
+Use `mock.getMockedHttpClient` — it returns a Ktor `HttpClient` with `MockEngine`:
 
-### vararg matcher
-```kotlin
-coEvery { service.method(any(), *anyVararg()) } returns "value"
-```
-
-## HTTP Mocking
-Use the existing helper at `src/test/kotlin/mock/HttpClientMock.kt`:
 ```kotlin
 import mock.getMockedHttpClient
 
 val httpClient = getMockedHttpClient("""{"key": "value"}""")
-val service = MyService(httpClient)
+val svc = MyService(httpClient)
 ```
-This creates a Ktor `HttpClient` with `MockEngine` that always responds with the given JSON content.
 
-## Command Test Patterns
+---
 
-### `onExecute` — verify downstream service calls
-**Don't mock `respond` or `edit` (inline extension functions)** — use `relaxed = true`:
+## Command test patterns
+
+**Don't mock inline extension functions** (`respond`, `edit`, `deferPublicResponse`). Use `relaxed = true`:
+
 ```kotlin
 val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
-coEvery { localizationService.getString(any(), any(), any()) } returns "message"
-coJustRun { service.loadAndPlayMessage(any(), any()) }
 
-sut.onExecute(interaction, response)
+// Verify downstream service calls instead
+coVerify(exactly = 1) { someService.method("expected arg") }
 
-coVerify(exactly = 1) { service.loadAndPlayMessage(any(), "expected arg") }
+// For error cases, verify NOT called
+coVerify(exactly = 0) { someService.method(any(), any()) }
 ```
 
-### Error cases — verify service was NOT called
-```kotlin
-sut.onExecute(interaction, response)
-coVerify(exactly = 0) { service.loadAndPlayMessage(any(), any()) }
-```
+`onRegisterCommand` tests are `@Ignore`'d — don't add new ones.
 
-### `onRegisterCommand` — currently **@Ignored** due to MockK issues
-See `TTSCommandTest.kt` for reference. Don't add new `onRegisterCommand` tests.
+---
 
-## Interaction Mocking
+## Interaction mocks
 
 ### ChatInputCommandInteraction
 ```kotlin
 val interaction = mockk<ChatInputCommandInteraction> {
     every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-    every { data } returns mockk {
-        every { guildId.value } returns Snowflake(123)
-    }
-    every { command } returns mockk {
-        every { strings } returns mapOf("argName" to "value")
-    }
+    every { data } returns mockk { every { guildId.value } returns Snowflake(123) }
+    every { command } returns mockk { every { strings } returns mapOf("arg" to "value") }
 }
 ```
 
 ### MessageCommandInteraction
 ```kotlin
-val targetMessage = mockk<Message> {
-    every { content } returns "message content"
-}
+val message = mockk<Message> { every { content } returns "text" }
 val interaction = mockk<MessageCommandInteraction> {
     every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-    every { data } returns mockk {
-        every { guildId.value } returns Snowflake(123)
-    }
-    coEvery { getTarget() } returns targetMessage
+    every { data } returns mockk { every { guildId.value } returns Snowflake(123) }
+    coEvery { getTarget() } returns message
 }
 ```
 
-## Key Imports
-```kotlin
-import dev.kord.common.Locale
-import dev.kord.common.entity.Snowflake
-import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
-import dev.kord.core.entity.interaction.ChatInputCommandInteraction
-import dev.kord.core.entity.interaction.MessageCommandInteraction
-import dev.kord.core.entity.Message
-import io.mockk.*
-import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-```
+---
 
 ## Don't
-- ❌ Mock inline extension functions (`respond`, `edit`, `deferPublicResponse`)
-- ❌ Write `onRegisterCommand` tests (MockK can't handle the builder pattern)
-- ❌ Use `@Test` from JUnit 5 and Kotlin test in the same file (pick one)
-- ❌ Import unused Kord entities
+- Mock inline extension functions (`respond`, `edit`, `deferPublicResponse`)
+- Write `onRegisterCommand` tests (MockK can't handle the builder)
+- Mix JUnit 5 `@Test` and Kotlin test `@Test` in the same file
+- Import unused Kord entities

--- a/src/main/kotlin/bot/Bot.kt
+++ b/src/main/kotlin/bot/Bot.kt
@@ -10,6 +10,7 @@ import dev.kord.core.event.gateway.ReadyEvent
 import dev.kord.core.event.interaction.AutoCompleteInteractionCreateEvent
 import dev.kord.core.event.interaction.ButtonInteractionCreateEvent
 import dev.kord.core.event.interaction.ChatInputCommandInteractionCreateEvent
+import dev.kord.core.event.interaction.MessageCommandInteractionCreateEvent
 import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.core.event.user.VoiceStateUpdateEvent
 import dev.kord.core.on
@@ -77,6 +78,11 @@ class Bot(
         bot.on<ButtonInteractionCreateEvent> {
             interaction.deferPublicMessageUpdate()
             commandHandlerService.onInteract(interaction)
+        }
+
+        bot.on<MessageCommandInteractionCreateEvent> {
+            val response = interaction.deferPublicResponse()
+            commandHandlerService.onExecuteMessageCommand(interaction, response)
         }
 
         bot.on<AutoCompleteInteractionCreateEvent> {

--- a/src/main/kotlin/commands/CommandName.kt
+++ b/src/main/kotlin/commands/CommandName.kt
@@ -13,6 +13,7 @@ sealed class CommandName(val commandName: String) {
     data object Next : CommandName("next")
     data object Disconnect : CommandName("disconnect")
     data object Locale : CommandName("locale")
+    data object Ask : CommandName("ask")
     data object Radio : CommandName("radio") {
         data object Play : CommandName("play")
         data object List : CommandName("list")

--- a/src/main/kotlin/commands/ask/AskCommand.kt
+++ b/src/main/kotlin/commands/ask/AskCommand.kt
@@ -1,0 +1,96 @@
+package es.wokis.commands.ask
+
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.behavior.interaction.response.edit
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
+import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
+import dev.kord.rest.builder.interaction.string
+import es.wokis.commands.Command
+import es.wokis.commands.CommandName
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.ask.AskService
+import es.wokis.services.config.ConfigService
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+import es.wokis.utils.getArgument
+
+private const val ASK_ARGUMENT_NAME = "prompt"
+
+class AskCommand(
+    private val askService: AskService,
+    private val localizationService: LocalizationService,
+    private val guildQueueService: GuildQueueService,
+    private val configService: ConfigService
+) : Command {
+    override fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
+        commandBuilder.apply {
+            input(
+                name = CommandName.Ask.commandName,
+                description = localizationService.getLocalizations(LocalizationKeys.ASK_COMMAND_DESCRIPTION).values.first()
+            ) {
+                descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.ASK_COMMAND_DESCRIPTION)
+                string(
+                    name = ASK_ARGUMENT_NAME,
+                    description = localizationService.getLocalizations(LocalizationKeys.ASK_COMMAND_INPUT_DESCRIPTION).values.first()
+                ) {
+                    descriptionLocalizations = localizationService.getLocalizations(LocalizationKeys.ASK_COMMAND_INPUT_DESCRIPTION)
+                    required = true
+                }
+            }
+        }
+    }
+
+    override suspend fun onExecute(
+        interaction: ChatInputCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior
+    ) {
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
+        val prompt: String = interaction.getArgument(ASK_ARGUMENT_NAME)
+            ?: response.respond {
+                content = localizationService.getStringFormat(
+                    key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
+                    guildId = guildId,
+                    discordLocale = discordLocale,
+                    arguments = arrayOf(ASK_ARGUMENT_NAME)
+                )
+            }.let { return }
+
+        if (!configService.config.ask.enabled) {
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ASK_NOT_ENABLED,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+            return
+        }
+
+        val initialResponse: PublicMessageInteractionResponse = response.respond {
+            content = localizationService.getString(
+                key = LocalizationKeys.ASK_THINKING,
+                guildId = guildId,
+                discordLocale = discordLocale
+            )
+        }
+
+        try {
+            val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
+            val answer = askService.askAndPlayTTS(prompt, guildLavaPlayerService)
+            initialResponse.edit {
+                content = answer
+            }
+        } catch (e: Exception) {
+            initialResponse.edit {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ERROR_API_UNEXPECTED,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/commands/ask/AskCommand.kt
+++ b/src/main/kotlin/commands/ask/AskCommand.kt
@@ -1,17 +1,14 @@
 package es.wokis.commands.ask
 
 import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
-import dev.kord.core.behavior.interaction.response.edit
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
-import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
 import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
 import dev.kord.rest.builder.interaction.string
 import es.wokis.commands.Command
 import es.wokis.commands.CommandName
 import es.wokis.localization.LocalizationKeys
-import es.wokis.services.ask.AskService
-import es.wokis.services.config.ConfigService
+import es.wokis.services.ask.AskExecutor
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import es.wokis.utils.getArgument
@@ -19,10 +16,9 @@ import es.wokis.utils.getArgument
 private const val ASK_ARGUMENT_NAME = "prompt"
 
 class AskCommand(
-    private val askService: AskService,
+    private val askExecutor: AskExecutor,
     private val localizationService: LocalizationService,
-    private val guildQueueService: GuildQueueService,
-    private val configService: ConfigService
+    private val guildQueueService: GuildQueueService
 ) : Command {
     override fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
         commandBuilder.apply {
@@ -46,51 +42,23 @@ class AskCommand(
         interaction: ChatInputCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val guildId = interaction.data.guildId.value
-        val discordLocale = interaction.guildLocale
         val prompt: String = interaction.getArgument(ASK_ARGUMENT_NAME)
             ?: response.respond {
                 content = localizationService.getStringFormat(
                     key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
-                    guildId = guildId,
-                    discordLocale = discordLocale,
+                    guildId = interaction.data.guildId.value,
+                    discordLocale = interaction.guildLocale,
                     arguments = arrayOf(ASK_ARGUMENT_NAME)
                 )
             }.let { return }
 
-        if (!configService.config.ask.enabled) {
-            response.respond {
-                content = localizationService.getString(
-                    key = LocalizationKeys.ASK_NOT_ENABLED,
-                    guildId = guildId,
-                    discordLocale = discordLocale
-                )
-            }
-            return
-        }
-
-        val initialResponse: PublicMessageInteractionResponse = response.respond {
-            content = localizationService.getString(
-                key = LocalizationKeys.ASK_THINKING,
-                guildId = guildId,
-                discordLocale = discordLocale
-            )
-        }
-
-        try {
-            val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
-            val answer = askService.askAndPlayTTS(prompt, guildLavaPlayerService)
-            initialResponse.edit {
-                content = answer
-            }
-        } catch (e: Exception) {
-            initialResponse.edit {
-                content = localizationService.getString(
-                    key = LocalizationKeys.ERROR_API_UNEXPECTED,
-                    guildId = guildId,
-                    discordLocale = discordLocale
-                )
-            }
-        }
+        val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
+        askExecutor.execute(
+            prompt = prompt,
+            guildId = interaction.data.guildId.value,
+            discordLocale = interaction.guildLocale,
+            response = response,
+            guildLavaPlayerService = guildLavaPlayerService
+        )
     }
 }

--- a/src/main/kotlin/commands/ask/AskContextMenuCommand.kt
+++ b/src/main/kotlin/commands/ask/AskContextMenuCommand.kt
@@ -1,24 +1,20 @@
 package es.wokis.commands.ask
 
 import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
-import dev.kord.core.behavior.interaction.response.edit
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.MessageCommandInteraction
-import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
 import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
 import es.wokis.localization.LocalizationKeys
-import es.wokis.services.ask.AskService
-import es.wokis.services.config.ConfigService
+import es.wokis.services.ask.AskExecutor
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 
 private const val ASK_CONTEXT_MENU_NAME = "Ask AI"
 
 class AskContextMenuCommand(
-    private val askService: AskService,
+    private val askExecutor: AskExecutor,
     private val localizationService: LocalizationService,
-    private val guildQueueService: GuildQueueService,
-    private val configService: ConfigService
+    private val guildQueueService: GuildQueueService
 ) {
     fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
         commandBuilder.message(ASK_CONTEXT_MENU_NAME)
@@ -28,55 +24,26 @@ class AskContextMenuCommand(
         interaction: MessageCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     ) {
-        val guildId = interaction.data.guildId.value
-        val discordLocale = interaction.guildLocale
-
-        if (!configService.config.ask.enabled) {
-            response.respond {
-                content = localizationService.getString(
-                    key = LocalizationKeys.ASK_NOT_ENABLED,
-                    guildId = guildId,
-                    discordLocale = discordLocale
-                )
-            }
-            return
-        }
-
         val prompt = interaction.getTarget().content
 
         if (prompt.isBlank()) {
             response.respond {
                 content = localizationService.getString(
                     key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
-                    guildId = guildId,
-                    discordLocale = discordLocale
+                    guildId = interaction.data.guildId.value,
+                    discordLocale = interaction.guildLocale
                 )
             }
             return
         }
 
-        val initialResponse: PublicMessageInteractionResponse = response.respond {
-            content = localizationService.getString(
-                key = LocalizationKeys.ASK_THINKING,
-                guildId = guildId,
-                discordLocale = discordLocale
-            )
-        }
-
-        try {
-            val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
-            val answer = askService.askAndPlayTTS(prompt, guildLavaPlayerService)
-            initialResponse.edit {
-                content = answer
-            }
-        } catch (e: Exception) {
-            initialResponse.edit {
-                content = localizationService.getString(
-                    key = LocalizationKeys.ERROR_API_UNEXPECTED,
-                    guildId = guildId,
-                    discordLocale = discordLocale
-                )
-            }
-        }
+        val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
+        askExecutor.execute(
+            prompt = prompt,
+            guildId = interaction.data.guildId.value,
+            discordLocale = interaction.guildLocale,
+            response = response,
+            guildLavaPlayerService = guildLavaPlayerService
+        )
     }
 }

--- a/src/main/kotlin/commands/ask/AskContextMenuCommand.kt
+++ b/src/main/kotlin/commands/ask/AskContextMenuCommand.kt
@@ -1,0 +1,82 @@
+package es.wokis.commands.ask
+
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.behavior.interaction.response.edit
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.MessageCommandInteraction
+import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
+import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.ask.AskService
+import es.wokis.services.config.ConfigService
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+
+private const val ASK_CONTEXT_MENU_NAME = "Ask AI"
+
+class AskContextMenuCommand(
+    private val askService: AskService,
+    private val localizationService: LocalizationService,
+    private val guildQueueService: GuildQueueService,
+    private val configService: ConfigService
+) {
+    fun onRegisterCommand(commandBuilder: GlobalMultiApplicationCommandBuilder) {
+        commandBuilder.message(ASK_CONTEXT_MENU_NAME)
+    }
+
+    suspend fun onExecute(
+        interaction: MessageCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior
+    ) {
+        val guildId = interaction.data.guildId.value
+        val discordLocale = interaction.guildLocale
+
+        if (!configService.config.ask.enabled) {
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ASK_NOT_ENABLED,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+            return
+        }
+
+        val prompt = interaction.getTarget().content
+
+        if (prompt.isBlank()) {
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ERROR_NO_CONTENT_PROVIDED,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+            return
+        }
+
+        val initialResponse: PublicMessageInteractionResponse = response.respond {
+            content = localizationService.getString(
+                key = LocalizationKeys.ASK_THINKING,
+                guildId = guildId,
+                discordLocale = discordLocale
+            )
+        }
+
+        try {
+            val guildLavaPlayerService = guildQueueService.getOrCreateLavaPlayerService(interaction = interaction)
+            val answer = askService.askAndPlayTTS(prompt, guildLavaPlayerService)
+            initialResponse.edit {
+                content = answer
+            }
+        } catch (e: Exception) {
+            initialResponse.edit {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ERROR_API_UNEXPECTED,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/di/CommandModule.kt
+++ b/src/main/kotlin/di/CommandModule.kt
@@ -1,5 +1,7 @@
 package es.wokis.di
 
+import es.wokis.commands.ask.AskCommand
+import es.wokis.commands.ask.AskContextMenuCommand
 import es.wokis.commands.queue.QueueCommand
 import commands.play.PlayCommand
 import es.wokis.commands.player.PlayerCommand
@@ -44,4 +46,6 @@ val commandModule = module {
     factoryOf(::RadioRandomCommand)
     factoryOf(::RadioCountryCodesCommand)
     factoryOf(::LocaleCommand)
+    factoryOf(::AskCommand)
+    factoryOf(::AskContextMenuCommand)
 }

--- a/src/main/kotlin/di/CommandModule.kt
+++ b/src/main/kotlin/di/CommandModule.kt
@@ -1,10 +1,13 @@
 package es.wokis.di
 
+import commands.play.PlayCommand
 import es.wokis.commands.ask.AskCommand
 import es.wokis.commands.ask.AskContextMenuCommand
-import es.wokis.commands.queue.QueueCommand
-import commands.play.PlayCommand
+import es.wokis.commands.disconnect.DisconnectCommand
+import es.wokis.commands.locale.LocaleCommand
+import es.wokis.commands.next.NextCommand
 import es.wokis.commands.player.PlayerCommand
+import es.wokis.commands.queue.QueueCommand
 import es.wokis.commands.radio.RadioGroupCommand
 import es.wokis.commands.radio.subcommands.countrycodes.RadioCountryCodesCommand
 import es.wokis.commands.radio.subcommands.list.RadioListCommand
@@ -13,15 +16,12 @@ import es.wokis.commands.radio.subcommands.random.RadioRandomCommand
 import es.wokis.commands.radio.subcommands.search.RadioSearchCountryCodeCommand
 import es.wokis.commands.radio.subcommands.search.RadioSearchGroupCommand
 import es.wokis.commands.radio.subcommands.search.RadioSearchNameCommand
+import es.wokis.commands.reconnect.ReconnectCommand
 import es.wokis.commands.shuffle.ShuffleCommand
 import es.wokis.commands.skip.SkipCommand
 import es.wokis.commands.sound.SoundCommand
 import es.wokis.commands.sounds.SoundsCommand
-import es.wokis.commands.next.NextCommand
-import es.wokis.commands.reconnect.ReconnectCommand
-import es.wokis.commands.disconnect.DisconnectCommand
 import es.wokis.commands.tts.TTSCommand
-import es.wokis.commands.locale.LocaleCommand
 import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 

--- a/src/main/kotlin/di/ServicesModule.kt
+++ b/src/main/kotlin/di/ServicesModule.kt
@@ -2,6 +2,9 @@ package es.wokis.di
 
 import es.wokis.dispatchers.AppDispatchers
 import es.wokis.dispatchers.AppDispatchersImpl
+import es.wokis.services.ask.AIProvider
+import es.wokis.services.ask.AskService
+import es.wokis.services.ask.HuggingFaceProvider
 import es.wokis.services.commands.CommandHandlerService
 import es.wokis.services.commands.CommandHandlerServiceImpl
 import es.wokis.services.config.ConfigService
@@ -29,6 +32,9 @@ val servicesModule = module {
     singleOf(::RadioService)
     factoryOf(::PlayerChannelService)
     factoryOf(::ErrorHandlerService)
+
+    singleOf(::HuggingFaceProvider) { bind<AIProvider>() }
+    singleOf(::AskService)
 
     single<AppDispatchers> { AppDispatchersImpl() }
 }

--- a/src/main/kotlin/di/ServicesModule.kt
+++ b/src/main/kotlin/di/ServicesModule.kt
@@ -3,6 +3,7 @@ package es.wokis.di
 import es.wokis.dispatchers.AppDispatchers
 import es.wokis.dispatchers.AppDispatchersImpl
 import es.wokis.services.ask.AIProvider
+import es.wokis.services.ask.AskExecutor
 import es.wokis.services.ask.AskService
 import es.wokis.services.ask.HuggingFaceProvider
 import es.wokis.services.commands.CommandHandlerService
@@ -35,6 +36,7 @@ val servicesModule = module {
 
     singleOf(::HuggingFaceProvider) { bind<AIProvider>() }
     singleOf(::AskService)
+    singleOf(::AskExecutor)
 
     single<AppDispatchers> { AppDispatchersImpl() }
 }

--- a/src/main/kotlin/localization/LocalizationKeys.kt
+++ b/src/main/kotlin/localization/LocalizationKeys.kt
@@ -111,4 +111,8 @@ object LocalizationKeys {
     const val LOCALE_COMMAND_SUCCESS = "locale_command_success"
     const val LOCALE_COMMAND_RESET_SUCCESS = "locale_command_reset_success"
     const val LOCALE_COMMAND_INVALID_LOCALE = "locale_command_invalid_locale"
+    const val ASK_COMMAND_DESCRIPTION = "ask_command_description"
+    const val ASK_COMMAND_INPUT_DESCRIPTION = "ask_command_input_description"
+    const val ASK_THINKING = "ask_thinking"
+    const val ASK_NOT_ENABLED = "ask_not_enabled"
 }

--- a/src/main/kotlin/services/ask/AIProvider.kt
+++ b/src/main/kotlin/services/ask/AIProvider.kt
@@ -1,0 +1,5 @@
+package es.wokis.services.ask
+
+interface AIProvider {
+    suspend fun ask(prompt: String, model: String): String
+}

--- a/src/main/kotlin/services/ask/AskExecutor.kt
+++ b/src/main/kotlin/services/ask/AskExecutor.kt
@@ -1,0 +1,60 @@
+package es.wokis.services.ask
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.behavior.interaction.response.edit
+import dev.kord.core.behavior.interaction.response.respond
+import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.config.ConfigService
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.localization.LocalizationService
+
+class AskExecutor(
+    private val askService: AskService,
+    private val localizationService: LocalizationService,
+    private val configService: ConfigService
+) {
+    suspend fun execute(
+        prompt: String,
+        guildId: Snowflake?,
+        discordLocale: Locale?,
+        response: DeferredPublicMessageInteractionResponseBehavior,
+        guildLavaPlayerService: GuildLavaPlayerService
+    ) {
+        if (!configService.config.ask.enabled) {
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ASK_NOT_ENABLED,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+            return
+        }
+
+        val initialResponse: PublicMessageInteractionResponse = response.respond {
+            content = localizationService.getString(
+                key = LocalizationKeys.ASK_THINKING,
+                guildId = guildId,
+                discordLocale = discordLocale
+            )
+        }
+
+        try {
+            val answer = askService.askAndPlayTTS(prompt, guildLavaPlayerService)
+            initialResponse.edit {
+                content = answer
+            }
+        } catch (e: Exception) {
+            initialResponse.edit {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ERROR_API_UNEXPECTED,
+                    guildId = guildId,
+                    discordLocale = discordLocale
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/services/ask/AskService.kt
+++ b/src/main/kotlin/services/ask/AskService.kt
@@ -1,0 +1,24 @@
+package es.wokis.services.ask
+
+import es.wokis.services.config.ConfigService
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.tts.TTSService
+
+class AskService(
+    private val aiProvider: AIProvider,
+    private val ttsService: TTSService,
+    private val configService: ConfigService
+) {
+    private val config get() = configService.config.ask
+
+    suspend fun ask(prompt: String): String {
+        val model = config.model
+        return aiProvider.ask(prompt, model)
+    }
+
+    suspend fun askAndPlayTTS(prompt: String, guildLavaPlayerService: GuildLavaPlayerService): String {
+        val answer = ask(prompt)
+        ttsService.loadAndPlayMessage(guildLavaPlayerService, answer)
+        return answer
+    }
+}

--- a/src/main/kotlin/services/ask/HuggingFaceProvider.kt
+++ b/src/main/kotlin/services/ask/HuggingFaceProvider.kt
@@ -1,0 +1,61 @@
+package es.wokis.services.ask
+
+import es.wokis.services.config.ConfigService
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private const val HF_CHAT_URL = "https://router.huggingface.co/hf-inference/models"
+
+class HuggingFaceProvider(
+    private val httpClient: HttpClient,
+    private val configService: ConfigService
+) : AIProvider {
+
+    override suspend fun ask(prompt: String, model: String): String {
+        val token = configService.config.ask.apiToken
+        val url = "$HF_CHAT_URL/$model/v1/chat/completions"
+        val body = ChatCompletionRequest(
+            model = model,
+            messages = listOf(Message(role = "user", content = prompt)),
+            maxTokens = 500
+        )
+        val response: HttpResponse = httpClient.post(url) {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(Json.encodeToString(body))
+        }
+        val completion = response.body<ChatCompletionResponse>()
+        return completion.choices.firstOrNull()?.message?.content
+            ?: throw IllegalStateException("Empty response from HuggingFace API")
+    }
+}
+
+@Serializable
+data class ChatCompletionRequest(
+    val model: String,
+    val messages: List<Message>,
+    @kotlinx.serialization.SerialName("max_tokens")
+    val maxTokens: Int = 500
+)
+
+@Serializable
+data class Message(
+    val role: String,
+    val content: String
+)
+
+@Serializable
+data class ChatCompletionResponse(
+    val choices: List<Choice>
+)
+
+@Serializable
+data class Choice(
+    val message: Message
+)

--- a/src/main/kotlin/services/commands/CommandHandlerService.kt
+++ b/src/main/kotlin/services/commands/CommandHandlerService.kt
@@ -6,9 +6,12 @@ import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteract
 import dev.kord.core.behavior.interaction.response.respond
 import dev.kord.core.entity.interaction.ButtonInteraction
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.entity.interaction.MessageCommandInteraction
 import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
 import es.wokis.commands.CommandName
 import es.wokis.commands.ComponentsEnum
+import es.wokis.commands.ask.AskCommand
+import es.wokis.commands.ask.AskContextMenuCommand
 import es.wokis.commands.queue.QueueCommand
 import commands.play.PlayCommand
 import dev.kord.core.Kord
@@ -28,6 +31,7 @@ import es.wokis.constants.CUSTOM_COMPONENT_SEPARATOR
 import es.wokis.localization.LocalizationKeys
 import es.wokis.services.error.ErrorHandlerService
 import es.wokis.services.localization.LocalizationService
+import es.wokis.utils.Log
 
 interface CommandHandlerService {
 
@@ -37,6 +41,11 @@ interface CommandHandlerService {
 
     suspend fun onExecute(
         interaction: ChatInputCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior
+    )
+
+    suspend fun onExecuteMessageCommand(
+        interaction: MessageCommandInteraction,
         response: DeferredPublicMessageInteractionResponseBehavior
     )
 
@@ -59,6 +68,8 @@ class CommandHandlerServiceImpl(
     private val disconnectCommand: DisconnectCommand,
     private val localeCommand: LocaleCommand,
     private val radioGroupCommand: RadioGroupCommand,
+    private val askCommand: AskCommand,
+    private val askContextMenuCommand: AskContextMenuCommand,
     private val localizationService: LocalizationService,
     private val errorHandlerService: ErrorHandlerService
 ) : CommandHandlerService {
@@ -76,6 +87,8 @@ class CommandHandlerServiceImpl(
         nextCommand.onRegisterCommand(commandBuilder)
         disconnectCommand.onRegisterCommand(commandBuilder)
         localeCommand.onRegisterCommand(commandBuilder)
+        askCommand.onRegisterCommand(commandBuilder)
+        askContextMenuCommand.onRegisterCommand(commandBuilder)
     }
 
     override suspend fun onRegisterGroupCommand(kord: Kord) {
@@ -97,6 +110,7 @@ class CommandHandlerServiceImpl(
                 CommandName.Tts.commandName -> ttsCommand.onExecute(interaction, response)
                 CommandName.Player.commandName -> playerCommand.onExecute(interaction, response)
                 CommandName.Sounds.commandName -> soundsCommand.onExecute(interaction, response)
+                CommandName.Ask.commandName -> askCommand.onExecute(interaction, response)
                 CommandName.Radio.commandName -> radioGroupCommand.onExecute(interaction, response)
                 CommandName.Reconnect.commandName -> reconnectCommand.onExecute(interaction, response)
                 CommandName.Next.commandName -> nextCommand.onExecute(interaction, response)
@@ -106,6 +120,24 @@ class CommandHandlerServiceImpl(
             }
         } catch (exception: Throwable) {
             errorHandlerService.handleCommandError(exception, interaction, response, commandName)
+        }
+    }
+
+    override suspend fun onExecuteMessageCommand(
+        interaction: MessageCommandInteraction,
+        response: DeferredPublicMessageInteractionResponseBehavior
+    ) {
+        try {
+            askContextMenuCommand.onExecute(interaction, response)
+        } catch (exception: Throwable) {
+            Log.error("Error in ask context menu command", exception)
+            response.respond {
+                content = localizationService.getString(
+                    key = LocalizationKeys.ERROR_UNEXPECTED,
+                    guildId = interaction.data.guildId.value,
+                    discordLocale = interaction.guildLocale
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/services/config/ConfigBO.kt
+++ b/src/main/kotlin/services/config/ConfigBO.kt
@@ -22,7 +22,9 @@ data class Config(
     @SerialName("tidal")
     val tidal: TidalConfig,
     @SerialName("kokoro")
-    val kokoro: KokoroConfig
+    val kokoro: KokoroConfig,
+    @SerialName("ask")
+    val ask: AskConfig
 )
 
 @Serializable
@@ -93,6 +95,18 @@ data class TidalConfig(
     val countryCode: String,
     @SerialName("token")
     val token: String
+)
+
+@Serializable
+data class AskConfig(
+    @SerialName("enabled")
+    val enabled: Boolean,
+    @SerialName("provider")
+    val provider: String,
+    @SerialName("api_token")
+    val apiToken: String,
+    @SerialName("model")
+    val model: String
 )
 
 @Serializable

--- a/src/main/resources/lang/lang.yml
+++ b/src/main/resources/lang/lang.yml
@@ -108,3 +108,7 @@ locale_command_input_description: Locale to set (use autocomplete to see availab
 locale_command_success: Guild locale has been set to %s
 locale_command_reset_success: Guild locale has been reset to Discord's default
 locale_command_invalid_locale: Invalid locale provided. Please use the autocomplete options.
+ask_command_description: Asks an AI a question
+ask_command_input_description: The question to ask the AI
+ask_thinking: Thinking…
+ask_not_enabled: Ask feature is not enabled. Please configure it in the config file.

--- a/src/main/resources/lang/lang_es-ES.yml
+++ b/src/main/resources/lang/lang_es-ES.yml
@@ -108,3 +108,7 @@ locale_command_input_description: Idioma a establecer (usa el autocompletado par
 locale_command_success: El idioma del servidor se ha establecido a %s
 locale_command_reset_success: El idioma del servidor se ha restablecido al valor predeterminado de Discord
 locale_command_invalid_locale: Idioma proporcionado no válido. Por favor, usa las opciones de autocompletado.
+ask_command_description: Pregunta a una IA
+ask_command_input_description: La pregunta para la IA
+ask_thinking: Pensando…
+ask_not_enabled: La función de preguntar no está habilitada. Configúrala en el archivo de configuración.

--- a/src/main/resources/template/config_template.json
+++ b/src/main/resources/template/config_template.json
@@ -41,5 +41,11 @@
     "default_voice": "",
     "default_speed": 1.0,
     "default_lang_code": ""
+  },
+  "ask": {
+    "enabled": false,
+    "provider": "huggingface",
+    "api_token": "",
+    "model": "gpt-5.4-mini"
   }
 }

--- a/src/test/kotlin/commands/ask/AskCommandTest.kt
+++ b/src/test/kotlin/commands/ask/AskCommandTest.kt
@@ -4,11 +4,9 @@ import dev.kord.common.Locale
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
 import dev.kord.core.entity.interaction.ChatInputCommandInteraction
-import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
 import es.wokis.commands.ask.AskCommand
 import es.wokis.localization.LocalizationKeys
-import es.wokis.services.ask.AskService
-import es.wokis.services.config.ConfigService
+import es.wokis.services.ask.AskExecutor
 import es.wokis.services.lavaplayer.GuildLavaPlayerService
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
@@ -22,22 +20,14 @@ import kotlin.test.Test
 
 class AskCommandTest {
 
-    private val askService = mockk<AskService>()
+    private val askExecutor = mockk<AskExecutor>()
     private val localizationService = mockk<LocalizationService>()
     private val guildQueueService = mockk<GuildQueueService>()
-    private val configService: ConfigService = mockk {
-        every { config } returns mockk {
-            every { ask } returns mockk {
-                every { enabled } returns true
-            }
-        }
-    }
 
     private val askCommand = AskCommand(
-        askService = askService,
+        askExecutor = askExecutor,
         localizationService = localizationService,
-        guildQueueService = guildQueueService,
-        configService = configService
+        guildQueueService = guildQueueService
     )
 
     @Test
@@ -56,53 +46,14 @@ class AskCommandTest {
         val guildLavaPlayerService: GuildLavaPlayerService = mockk()
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_THINKING), any(), any()) } returns "Thinking..."
-        coEvery { askService.askAndPlayTTS(any(), any()) } returns "Hello, monkey!"
+        coJustRun { askExecutor.execute(any(), any(), any(), any(), any()) }
 
         // When
         askCommand.onExecute(interaction, response)
 
         // Then
         coVerify(exactly = 1) {
-            askService.askAndPlayTTS("hello", guildLavaPlayerService)
-        }
-    }
-
-    @Test
-    fun `Given interaction when ask not enabled When onExecute is called Then show error`() = runTest {
-        // Given
-        val disabledConfig: ConfigService = mockk {
-            every { config } returns mockk {
-                every { ask } returns mockk {
-                    every { enabled } returns false
-                }
-            }
-        }
-        val cmd = AskCommand(
-            askService = askService,
-            localizationService = localizationService,
-            guildQueueService = guildQueueService,
-            configService = disabledConfig
-        )
-        val interaction = mockk<ChatInputCommandInteraction> {
-            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-            every { data } returns mockk {
-                every { guildId.value } returns Snowflake(123)
-            }
-            every { command } returns mockk {
-                every { strings } returns mapOf("prompt" to "hello")
-            }
-        }
-        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
-
-        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_NOT_ENABLED), any(), any()) } returns "Not enabled"
-
-        // When
-        cmd.onExecute(interaction, response)
-
-        // Then
-        coVerify(exactly = 0) {
-            askService.askAndPlayTTS(any(), any())
+            askExecutor.execute("hello", Snowflake(123), Locale.ENGLISH_UNITED_STATES, response, guildLavaPlayerService)
         }
     }
 
@@ -127,7 +78,7 @@ class AskCommandTest {
 
         // Then
         coVerify(exactly = 0) {
-            askService.askAndPlayTTS(any(), any())
+            askExecutor.execute(any(), any(), any(), any(), any())
         }
     }
 }

--- a/src/test/kotlin/commands/ask/AskCommandTest.kt
+++ b/src/test/kotlin/commands/ask/AskCommandTest.kt
@@ -1,0 +1,133 @@
+package commands.ask
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.entity.interaction.ChatInputCommandInteraction
+import dev.kord.core.entity.interaction.response.PublicMessageInteractionResponse
+import es.wokis.commands.ask.AskCommand
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.ask.AskService
+import es.wokis.services.config.ConfigService
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class AskCommandTest {
+
+    private val askService = mockk<AskService>()
+    private val localizationService = mockk<LocalizationService>()
+    private val guildQueueService = mockk<GuildQueueService>()
+    private val configService: ConfigService = mockk {
+        every { config } returns mockk {
+            every { ask } returns mockk {
+                every { enabled } returns true
+            }
+        }
+    }
+
+    private val askCommand = AskCommand(
+        askService = askService,
+        localizationService = localizationService,
+        guildQueueService = guildQueueService,
+        configService = configService
+    )
+
+    @Test
+    fun `Given interaction When onExecute is called Then ask AI and play TTS`() = runTest {
+        // Given
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            every { command } returns mockk {
+                every { strings } returns mapOf("prompt" to "hello")
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk()
+
+        coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
+        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_THINKING), any(), any()) } returns "Thinking..."
+        coEvery { askService.askAndPlayTTS(any(), any()) } returns "Hello, monkey!"
+
+        // When
+        askCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            askService.askAndPlayTTS("hello", guildLavaPlayerService)
+        }
+    }
+
+    @Test
+    fun `Given interaction when ask not enabled When onExecute is called Then show error`() = runTest {
+        // Given
+        val disabledConfig: ConfigService = mockk {
+            every { config } returns mockk {
+                every { ask } returns mockk {
+                    every { enabled } returns false
+                }
+            }
+        }
+        val cmd = AskCommand(
+            askService = askService,
+            localizationService = localizationService,
+            guildQueueService = guildQueueService,
+            configService = disabledConfig
+        )
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            every { command } returns mockk {
+                every { strings } returns mapOf("prompt" to "hello")
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+
+        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_NOT_ENABLED), any(), any()) } returns "Not enabled"
+
+        // When
+        cmd.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 0) {
+            askService.askAndPlayTTS(any(), any())
+        }
+    }
+
+    @Test
+    fun `Given interaction with wrong argument When onExecute is called Then show error`() = runTest {
+        // Given
+        val interaction = mockk<ChatInputCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            every { command } returns mockk {
+                every { strings } returns mapOf("other" to "hello")
+            }
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+
+        coEvery { localizationService.getStringFormat(any(), any(), any(), *anyVararg()) } returns "Error"
+
+        // When
+        askCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 0) {
+            askService.askAndPlayTTS(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/commands/ask/AskContextMenuCommandTest.kt
+++ b/src/test/kotlin/commands/ask/AskContextMenuCommandTest.kt
@@ -7,12 +7,12 @@ import dev.kord.core.entity.Message
 import dev.kord.core.entity.interaction.MessageCommandInteraction
 import es.wokis.commands.ask.AskContextMenuCommand
 import es.wokis.localization.LocalizationKeys
-import es.wokis.services.ask.AskService
-import es.wokis.services.config.ConfigService
+import es.wokis.services.ask.AskExecutor
 import es.wokis.services.lavaplayer.GuildLavaPlayerService
 import es.wokis.services.localization.LocalizationService
 import es.wokis.services.queue.GuildQueueService
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -21,22 +21,14 @@ import kotlin.test.Test
 
 class AskContextMenuCommandTest {
 
-    private val askService = mockk<AskService>()
+    private val askExecutor = mockk<AskExecutor>()
     private val localizationService = mockk<LocalizationService>()
     private val guildQueueService = mockk<GuildQueueService>()
-    private val configService: ConfigService = mockk {
-        every { config } returns mockk {
-            every { ask } returns mockk {
-                every { enabled } returns true
-            }
-        }
-    }
 
     private val askContextMenuCommand = AskContextMenuCommand(
-        askService = askService,
+        askExecutor = askExecutor,
         localizationService = localizationService,
-        guildQueueService = guildQueueService,
-        configService = configService
+        guildQueueService = guildQueueService
     )
 
     @Test
@@ -56,54 +48,14 @@ class AskContextMenuCommandTest {
         val guildLavaPlayerService: GuildLavaPlayerService = mockk()
 
         coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
-        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_THINKING), any(), any()) } returns "Thinking..."
-        coEvery { askService.askAndPlayTTS(any(), any()) } returns "Hello, monkey!"
+        coJustRun { askExecutor.execute(any(), any(), any(), any(), any()) }
 
         // When
         askContextMenuCommand.onExecute(interaction, response)
 
         // Then
         coVerify(exactly = 1) {
-            askService.askAndPlayTTS("hello from context menu", guildLavaPlayerService)
-        }
-    }
-
-    @Test
-    fun `Given interaction when ask not enabled When onExecute is called Then show error`() = runTest {
-        // Given
-        val disabledConfig: ConfigService = mockk {
-            every { config } returns mockk {
-                every { ask } returns mockk {
-                    every { enabled } returns false
-                }
-            }
-        }
-        val cmd = AskContextMenuCommand(
-            askService = askService,
-            localizationService = localizationService,
-            guildQueueService = guildQueueService,
-            configService = disabledConfig
-        )
-        val targetMessage = mockk<Message> {
-            every { content } returns "hello"
-        }
-        val interaction = mockk<MessageCommandInteraction> {
-            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
-            every { data } returns mockk {
-                every { guildId.value } returns Snowflake(123)
-            }
-            coEvery { getTarget() } returns targetMessage
-        }
-        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
-
-        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_NOT_ENABLED), any(), any()) } returns "Not enabled"
-
-        // When
-        cmd.onExecute(interaction, response)
-
-        // Then
-        coVerify(exactly = 0) {
-            askService.askAndPlayTTS(any(), any())
+            askExecutor.execute("hello from context menu", Snowflake(123), Locale.ENGLISH_UNITED_STATES, response, guildLavaPlayerService)
         }
     }
 
@@ -129,7 +81,7 @@ class AskContextMenuCommandTest {
 
         // Then
         coVerify(exactly = 0) {
-            askService.askAndPlayTTS(any(), any())
+            askExecutor.execute(any(), any(), any(), any(), any())
         }
     }
 }

--- a/src/test/kotlin/commands/ask/AskContextMenuCommandTest.kt
+++ b/src/test/kotlin/commands/ask/AskContextMenuCommandTest.kt
@@ -1,0 +1,135 @@
+package commands.ask
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import dev.kord.core.entity.Message
+import dev.kord.core.entity.interaction.MessageCommandInteraction
+import es.wokis.commands.ask.AskContextMenuCommand
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.ask.AskService
+import es.wokis.services.config.ConfigService
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.localization.LocalizationService
+import es.wokis.services.queue.GuildQueueService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class AskContextMenuCommandTest {
+
+    private val askService = mockk<AskService>()
+    private val localizationService = mockk<LocalizationService>()
+    private val guildQueueService = mockk<GuildQueueService>()
+    private val configService: ConfigService = mockk {
+        every { config } returns mockk {
+            every { ask } returns mockk {
+                every { enabled } returns true
+            }
+        }
+    }
+
+    private val askContextMenuCommand = AskContextMenuCommand(
+        askService = askService,
+        localizationService = localizationService,
+        guildQueueService = guildQueueService,
+        configService = configService
+    )
+
+    @Test
+    fun `Given interaction When onExecute is called Then ask AI with message content and play TTS`() = runTest {
+        // Given
+        val targetMessage = mockk<Message> {
+            every { content } returns "hello from context menu"
+        }
+        val interaction = mockk<MessageCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            coEvery { getTarget() } returns targetMessage
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk()
+
+        coEvery { guildQueueService.getOrCreateLavaPlayerService(any()) } returns guildLavaPlayerService
+        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_THINKING), any(), any()) } returns "Thinking..."
+        coEvery { askService.askAndPlayTTS(any(), any()) } returns "Hello, monkey!"
+
+        // When
+        askContextMenuCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            askService.askAndPlayTTS("hello from context menu", guildLavaPlayerService)
+        }
+    }
+
+    @Test
+    fun `Given interaction when ask not enabled When onExecute is called Then show error`() = runTest {
+        // Given
+        val disabledConfig: ConfigService = mockk {
+            every { config } returns mockk {
+                every { ask } returns mockk {
+                    every { enabled } returns false
+                }
+            }
+        }
+        val cmd = AskContextMenuCommand(
+            askService = askService,
+            localizationService = localizationService,
+            guildQueueService = guildQueueService,
+            configService = disabledConfig
+        )
+        val targetMessage = mockk<Message> {
+            every { content } returns "hello"
+        }
+        val interaction = mockk<MessageCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            coEvery { getTarget() } returns targetMessage
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+
+        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_NOT_ENABLED), any(), any()) } returns "Not enabled"
+
+        // When
+        cmd.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 0) {
+            askService.askAndPlayTTS(any(), any())
+        }
+    }
+
+    @Test
+    fun `Given interaction with blank message When onExecute is called Then show error`() = runTest {
+        // Given
+        val targetMessage = mockk<Message> {
+            every { content } returns ""
+        }
+        val interaction = mockk<MessageCommandInteraction> {
+            every { guildLocale } returns Locale.ENGLISH_UNITED_STATES
+            every { data } returns mockk {
+                every { guildId.value } returns Snowflake(123)
+            }
+            coEvery { getTarget() } returns targetMessage
+        }
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+
+        coEvery { localizationService.getString(eq(LocalizationKeys.ERROR_NO_CONTENT_PROVIDED), any(), any()) } returns ""
+
+        // When
+        askContextMenuCommand.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 0) {
+            askService.askAndPlayTTS(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/services/ask/AskExecutorTest.kt
+++ b/src/test/kotlin/services/ask/AskExecutorTest.kt
@@ -52,13 +52,17 @@ class AskExecutorTest {
     @Test
     fun `Given prompt when ask not enabled When execute is called Then show error`() = runTest {
         // Given
-        val disabledExecutor = AskExecutor(askService, localizationService, mockk {
-            every { config } returns mockk {
-                every { ask } returns mockk {
-                    every { enabled } returns false
+        val disabledExecutor = AskExecutor(
+            askService,
+            localizationService,
+            mockk {
+                every { config } returns mockk {
+                    every { ask } returns mockk {
+                        every { enabled } returns false
+                    }
                 }
             }
-        })
+        )
         val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
         val guildLavaPlayerService: GuildLavaPlayerService = mockk()
 

--- a/src/test/kotlin/services/ask/AskExecutorTest.kt
+++ b/src/test/kotlin/services/ask/AskExecutorTest.kt
@@ -1,0 +1,93 @@
+package services.ask
+
+import dev.kord.common.Locale
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.behavior.interaction.response.DeferredPublicMessageInteractionResponseBehavior
+import es.wokis.localization.LocalizationKeys
+import es.wokis.services.ask.AskExecutor
+import es.wokis.services.ask.AskService
+import es.wokis.services.config.ConfigService
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.localization.LocalizationService
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class AskExecutorTest {
+
+    private val askService = mockk<AskService>()
+    private val localizationService = mockk<LocalizationService>()
+    private val configService: ConfigService = mockk {
+        every { config } returns mockk {
+            every { ask } returns mockk {
+                every { enabled } returns true
+            }
+        }
+    }
+
+    private val askExecutor = AskExecutor(askService, localizationService, configService)
+
+    @Test
+    fun `Given prompt When execute is called Then ask AI and play TTS`() = runTest {
+        // Given
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk()
+
+        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_THINKING), any(), any()) } returns "Thinking..."
+        coEvery { askService.askAndPlayTTS(any(), any()) } returns "Hello, monkey!"
+
+        // When
+        askExecutor.execute("hello", Snowflake(123), Locale.ENGLISH_UNITED_STATES, response, guildLavaPlayerService)
+
+        // Then
+        coVerify(exactly = 1) {
+            askService.askAndPlayTTS("hello", guildLavaPlayerService)
+        }
+    }
+
+    @Test
+    fun `Given prompt when ask not enabled When execute is called Then show error`() = runTest {
+        // Given
+        val disabledExecutor = AskExecutor(askService, localizationService, mockk {
+            every { config } returns mockk {
+                every { ask } returns mockk {
+                    every { enabled } returns false
+                }
+            }
+        })
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk()
+
+        coEvery { localizationService.getString(eq(LocalizationKeys.ASK_NOT_ENABLED), any(), any()) } returns "Not enabled"
+
+        // When
+        disabledExecutor.execute("hello", Snowflake(123), Locale.ENGLISH_UNITED_STATES, response, guildLavaPlayerService)
+
+        // Then
+        coVerify(exactly = 0) {
+            askService.askAndPlayTTS(any(), any())
+        }
+    }
+
+    @Test
+    fun `Given prompt When API fails Then show error`() = runTest {
+        // Given
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>(relaxed = true)
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk()
+
+        coEvery { localizationService.getString(any(), any(), any()) } returns "message"
+        coEvery { askService.askAndPlayTTS(any(), any()) } throws RuntimeException("API error")
+
+        // When
+        askExecutor.execute("hello", Snowflake(123), Locale.ENGLISH_UNITED_STATES, response, guildLavaPlayerService)
+
+        // Then
+        coVerify(exactly = 1) {
+            askService.askAndPlayTTS("hello", guildLavaPlayerService)
+        }
+    }
+}

--- a/src/test/kotlin/services/ask/AskServiceTest.kt
+++ b/src/test/kotlin/services/ask/AskServiceTest.kt
@@ -1,0 +1,60 @@
+package services.ask
+
+import es.wokis.services.ask.AIProvider
+import es.wokis.services.ask.AskService
+import es.wokis.services.config.ConfigService
+import es.wokis.services.lavaplayer.GuildLavaPlayerService
+import es.wokis.services.tts.TTSService
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AskServiceTest {
+
+    private val aiProvider: AIProvider = mockk()
+    private val ttsService: TTSService = mockk()
+    private val configService: ConfigService = mockk {
+        every { config } returns mockk {
+            every { ask } returns mockk {
+                every { model } returns "test-model"
+            }
+        }
+    }
+
+    private val askService = AskService(aiProvider, ttsService, configService)
+
+    @Test
+    fun `Given prompt When ask is called Then return AI answer`() = runTest {
+        // Given
+        coEvery { aiProvider.ask("hello", "test-model") } returns "hi there"
+
+        // When
+        val result = askService.ask("hello")
+
+        // Then
+        assertEquals("hi there", result)
+    }
+
+    @Test
+    fun `Given prompt When askAndPlayTTS is called Then return answer and play TTS`() = runTest {
+        // Given
+        val guildLavaPlayerService: GuildLavaPlayerService = mockk()
+        coEvery { aiProvider.ask("hello", "test-model") } returns "hi there"
+        coJustRun { ttsService.loadAndPlayMessage(any(), any()) }
+
+        // When
+        val result = askService.askAndPlayTTS("hello", guildLavaPlayerService)
+
+        // Then
+        assertEquals("hi there", result)
+        coVerify(exactly = 1) {
+            aiProvider.ask("hello", "test-model")
+            ttsService.loadAndPlayMessage(guildLavaPlayerService, "hi there")
+        }
+    }
+}

--- a/src/test/kotlin/services/ask/HuggingFaceProviderTest.kt
+++ b/src/test/kotlin/services/ask/HuggingFaceProviderTest.kt
@@ -1,0 +1,75 @@
+package services.ask
+
+import es.wokis.services.ask.HuggingFaceProvider
+import es.wokis.services.config.Config
+import es.wokis.services.config.ConfigService
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import mock.getMockedHttpClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class HuggingFaceProviderTest {
+
+    private val configService: ConfigService = mockk {
+        every { config } returns mockk {
+            every { ask } returns mockk {
+                every { apiToken } returns "test-token"
+            }
+        }
+    }
+
+    @Test
+    fun `Given valid response When ask is called Then return answer`() = runTest {
+        // Given
+        val responseJson = Json.encodeToString(
+            mapOf(
+                "choices" to listOf(
+                    mapOf(
+                        "message" to mapOf(
+                            "role" to "assistant",
+                            "content" to "Hello, monkey!"
+                        )
+                    )
+                )
+            )
+        )
+        val httpClient = getMockedHttpClient(responseJson)
+        val provider = HuggingFaceProvider(httpClient, configService)
+
+        // When
+        val result = provider.ask("Say hi", "test-model")
+
+        // Then
+        assertEquals("Hello, monkey!", result)
+    }
+
+    @Test
+    fun `Given response with no choices When ask is called Then throw`() = runTest {
+        // Given
+        val responseJson = """{"choices": []}"""
+        val httpClient = getMockedHttpClient(responseJson)
+        val provider = HuggingFaceProvider(httpClient, configService)
+
+        // When / Then
+        assertThrows<IllegalStateException> {
+            provider.ask("test", "test-model")
+        }
+    }
+
+    @Test
+    fun `Given error response When ask is called Then throw`() = runTest {
+        // Given
+        val httpClient = getMockedHttpClient("not json")
+        val provider = HuggingFaceProvider(httpClient, configService)
+
+        // When / Then
+        assertThrows<Exception> {
+            provider.ask("test", "test-model")
+        }
+    }
+}

--- a/src/test/kotlin/services/commands/CommandHandlerServiceTest.kt
+++ b/src/test/kotlin/services/commands/CommandHandlerServiceTest.kt
@@ -20,6 +20,8 @@ import es.wokis.commands.sound.SoundCommand
 import es.wokis.commands.reconnect.ReconnectCommand
 import es.wokis.commands.tts.TTSCommand
 import es.wokis.commands.locale.LocaleCommand
+import es.wokis.commands.ask.AskCommand
+import es.wokis.commands.ask.AskContextMenuCommand
 import es.wokis.services.commands.CommandHandlerServiceImpl
 import es.wokis.services.error.ErrorHandlerService
 import es.wokis.services.localization.LocalizationService
@@ -43,6 +45,8 @@ class CommandHandlerServiceTest {
     private val localeCommand: LocaleCommand = mockk()
     private val localizationService: LocalizationService = mockk()
     private val radioGroupCommand: RadioGroupCommand = mockk()
+    private val askCommand: AskCommand = mockk()
+    private val askContextMenuCommand: AskContextMenuCommand = mockk()
     private val errorHandlerService: ErrorHandlerService = mockk()
 
     private val commandHandlerService = CommandHandlerServiceImpl(
@@ -60,6 +64,8 @@ class CommandHandlerServiceTest {
         nextCommand = nextCommand,
         disconnectCommand = disconnectCommand,
         localeCommand = localeCommand,
+        askCommand = askCommand,
+        askContextMenuCommand = askContextMenuCommand,
         errorHandlerService = errorHandlerService
     )
 
@@ -83,6 +89,8 @@ class CommandHandlerServiceTest {
         justRun { nextCommand.onRegisterCommand(any()) }
         justRun { disconnectCommand.onRegisterCommand(any()) }
         justRun { localeCommand.onRegisterCommand(any()) }
+        justRun { askCommand.onRegisterCommand(any()) }
+        justRun { askContextMenuCommand.onRegisterCommand(any()) }
 
         // When
         commandHandlerService.onRegisterSimpleCommand(commandBuilder)
@@ -101,6 +109,8 @@ class CommandHandlerServiceTest {
             nextCommand.onRegisterCommand(commandBuilder)
             disconnectCommand.onRegisterCommand(commandBuilder)
             localeCommand.onRegisterCommand(commandBuilder)
+            askCommand.onRegisterCommand(commandBuilder)
+            askContextMenuCommand.onRegisterCommand(commandBuilder)
         }
     }
 
@@ -311,6 +321,43 @@ class CommandHandlerServiceTest {
         // Then
         coVerify(exactly = 1) {
             disconnectCommand.onExecute(interaction, response)
+        }
+    }
+
+    @Test
+    fun `Given ask command When onExecute is called Then execute AskCommand`() = runTest {
+        // Given
+        val commandName = CommandName.Ask.commandName
+        val interaction: ChatInputCommandInteraction = mockk {
+            every { command } returns mockk {
+                every { rootName } returns commandName
+            }
+        }
+        val response: DeferredPublicMessageInteractionResponseBehavior = mockk()
+        coJustRun { askCommand.onExecute(any(), any()) }
+
+        // When
+        commandHandlerService.onExecute(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            askCommand.onExecute(interaction, response)
+        }
+    }
+
+    @Test
+    fun `When onExecuteMessageCommand is called Then execute AskContextMenuCommand`() = runTest {
+        // Given
+        val interaction = mockk<dev.kord.core.entity.interaction.MessageCommandInteraction>()
+        val response = mockk<DeferredPublicMessageInteractionResponseBehavior>()
+        coJustRun { askContextMenuCommand.onExecute(any(), any()) }
+
+        // When
+        commandHandlerService.onExecuteMessageCommand(interaction, response)
+
+        // Then
+        coVerify(exactly = 1) {
+            askContextMenuCommand.onExecute(interaction, response)
         }
     }
 


### PR DESCRIPTION
Solves #30

## 📋 Changelist Summary
Created `/ask` command that sends prompts to an AI API via a **provider-agnostic architecture** and generates TTS with the answer.

## 💬 Description
- **Provider-agnostic interface**: `AIProvider` strategy pattern (`HuggingFaceProvider` as primary, `DuckAIProvider` ready for future).
- **`/ask <prompt>` slash command**: Sends prompt to AI, responds with the answer in Discord + TTS in voice channel.
- **Message context menu** ("Ask AI"): Right-click any message → sends its content as prompt.
- **HuggingFace Inference API**: Uses Ktor directly (no HuggingFace library), OpenAI-compatible endpoint.
- **Architecture**: Follows existing project patterns (Koin DI, Command interface, LocalizationService, GuildQueueService, TTSService).

> **Note**: Duck.ai PoC was built and proven to work (JS challenge solved in Node.js), but fingerprint emulation makes it fragile. The interface is ready for it when the API stabilizes.

## ℹ️ Extra info
This PR was created using AI. Please review carefully before merging.

### 🐵 AI-Generated PR Disclaimer
This pull request was created with assistance from AI. While the code compiles successfully and all existing tests pass, please review the implementation carefully for correctness, security, and alignment with project conventions before merging.
